### PR TITLE
Potential fix for code scanning alert no. 2: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/ruby/src/training_data.rb
+++ b/ruby/src/training_data.rb
@@ -8,7 +8,7 @@ class TrainingData
   end
 
   def export(dirname)
-    IO.write(filename(dirname), to_json(training_data))
+    File.write(filename(dirname), to_json(training_data))
   end
 
   private


### PR DESCRIPTION
Potential fix for [https://github.com/hayat01sh1da/botpress-accuracy-checkers/security/code-scanning/2](https://github.com/hayat01sh1da/botpress-accuracy-checkers/security/code-scanning/2)

To fix the problem, we should replace the use of `IO.write` with `File.write`. This change will mitigate the risk of arbitrary code execution by ensuring that the filename is handled in a safer manner. The functionality of the code will remain the same, as `File.write` is a direct and safer alternative to `IO.write`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
