### PR TITLE
Potential fix for code scanning alert no. 1: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/ruby-on-rails/spec/lib/chart_drawer_spec.rb
+++ b/ruby-on-rails/spec/lib/chart_drawer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ChartDrawer do
   let(:csv_path)     { Rails.root.join('csv', 'test_data.csv') }
   let(:json_path)    { Rails.root.join('json', 'res_bodies.json') }
   let(:test_data)    { CSV.read(csv_path) }
-  let(:res_bodies)   { IO.read(json_path).then { |json| JSON.parse(json) } }
+  let(:res_bodies)   { File.read(json_path).then { |json| JSON.parse(json) } }
 
   it 'returns the same number of rows in the CSV chart as that in the test data' do
     expect(test_data.size).to eq(csv_chart.split(/\n/).size)


### PR DESCRIPTION
Potential fix for [https://github.com/hayat01sh1da/botpress-accuracy-checkers/security/code-scanning/1](https://github.com/hayat01sh1da/botpress-accuracy-checkers/security/code-scanning/1)

To fix the problem, we should replace the `IO.read` method with `File.read`. This change will mitigate the risk of executing arbitrary code through a maliciously crafted file path. The functionality of reading the JSON file and parsing it will remain the same.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
