### PR TITLE
[ruby-on-rails] Remove Verbose Procedure When App Starts

### DIFF
--- a/ruby-on-rails/docker-compose.yml
+++ b/ruby-on-rails/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     ports:
       - "3000:3000"
-    command: sh -c "bundle install && rm -f tmp/pids/server.pid && bin/rails s -b 0.0.0.0 -p 3000"
+    command: sh -c "rm -f tmp/pids/server.pid && bin/rails s -b 0.0.0.0 -p 3000"
     environment:
       # Suppress Ruby warnings during runtime by setting RUBYOPT=-W0 (silences warnings)
       - RUBYOPT=-W0


### PR DESCRIPTION
## Summary

Gem installation procedure via bundler is defined on `docker-compose.yml`, not just on `Dockerfile`.
It is too redundant, so it should be removed from the former file becuase the container makes use of cache on the allocated volume.