### PR TITLE
[ruby] Replace #size with #length to Prevent Unexpected Behaviour in the Case of Integer

### DIFF
--- a/ruby-on-rails/app/lib/chart_drawer.rb
+++ b/ruby-on-rails/app/lib/chart_drawer.rb
@@ -24,7 +24,7 @@ class ChartDrawer
 
   def score_tables
     res_bodies.map { |res_body|
-      (0...res_body['suggestions'].size).map { |index|
+      (0...res_body['suggestions'].length).map { |index|
         score_table         = Hash.new
         answer              = res_body['suggestions'][index]['payloads'][0]['text']
         score               = res_body['suggestions'][index]['confidence']
@@ -37,7 +37,7 @@ class ChartDrawer
   def rows
     score_tables.map { |score_table|
       scores = Array.new
-      scores.fill('0.0%', 0...test_data['Answer'].size)
+      scores.fill('0.0%', 0...test_data['Answer'].length)
       score_table.map { |score_mapping|
         score_mapping.each { |answer, score|
           index         = test_data['Answer'].find_index(answer)

--- a/ruby-on-rails/spec/lib/chart_drawer_spec.rb
+++ b/ruby-on-rails/spec/lib/chart_drawer_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe ChartDrawer do
   let(:res_bodies)   { File.read(json_path).then { |json| JSON.parse(json) } }
 
   it 'returns the same number of rows in the CSV chart as that in the test data' do
-    expect(test_data.size).to eq(csv_chart.split(/\n/).size)
+    expect(test_data.length).to eq(csv_chart.split(/\n/).length)
   end
 end

--- a/ruby/src/lib/chart_drawer.rb
+++ b/ruby/src/lib/chart_drawer.rb
@@ -25,7 +25,7 @@ module Lib
 
     def score_tables
       res_bodies.map { |res_body|
-        (0...res_body['suggestions'].size).map { |index|
+        (0...res_body['suggestions'].length).map { |index|
           score_table         = Hash.new
           answer              = res_body['suggestions'][index]['payloads'][0]['text']
           score               = res_body['suggestions'][index]['confidence']
@@ -38,7 +38,7 @@ module Lib
     def rows
       score_tables.map { |score_table|
         scores = Array.new
-        scores.fill('0.0%', 0...test_data['Answer'].size)
+        scores.fill('0.0%', 0...test_data['Answer'].length)
         score_table.map { |score_mapping|
           score_mapping.each { |answer, score|
             index         = test_data['Answer'].find_index(answer)

--- a/ruby/test/lib/chart_drawer_test.rb
+++ b/ruby/test/lib/chart_drawer_test.rb
@@ -14,7 +14,7 @@ class ChartDrawerTest < Minitest::Test
   def test_csv
     csv_chart = chart_drawer.csv
     test_data = CSV.read(csv_path)
-    assert_equal test_data.size, csv_chart.split(/\n/).size
+    assert_equal test_data.length, csv_chart.split(/\n/).length
   end
 
   private

--- a/ruby/test/queries/accuracy_check_query_test.rb
+++ b/ruby/test/queries/accuracy_check_query_test.rb
@@ -16,7 +16,7 @@
 #   def test_res_bodies
 #     res_bodies = accuracy_check_query.res_bodies
 #     test_data  = CSV.read(csv_path, headers: true)
-#     assert_equal test_data.size, res_bodies.size
+#     assert_equal test_data.length, res_bodies.length
 #   end
 
 #   private


### PR DESCRIPTION
## Summary

When the receiver is one of Array, Hash or String, there is basically no difference in terms of return value which represents the number of elements.
However, if it's of Integer, it returns the number of bytes in the machine representation of self; the value is system-dependent.
It may cause unexpected behaviours, so it should be replaced with #length because `Integer#length` raises `NoMethodError`.

Ref. https://docs.ruby-lang.org/en/master/Integer.html#method-i-size