### PR TITLE
[python] Remove Redudant Conditional Statement by Passing Option

### DIFF
--- a/python/test/test_application.py
+++ b/python/test/test_application.py
@@ -7,8 +7,7 @@ class TestApplication(unittest.TestCase):
     def setUp(self):
         self.dirname  = os.path.join('test', 'tmp')
         self.pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
-        if not os.path.exists(self.dirname):
-            os.makedirs(self.dirname)
+        os.makedirs(self.dirname, exist_ok = True)
 
     def tearDown(self):
         if os.path.exists(self.dirname):


### PR DESCRIPTION
## Summary

`os.makedirs` raises `FileExistsError` if the target directory already exists.
To prevent the error, it a had conditional statement.
The redundancy can be resolved by `exist_ok = True` option by ignoring the error.

```python
dirname = os.path.join('.', 'foo', 'bar')
os.makedirs(dirname)

# Ignores FileExistsError with the option
os.makedirs(dirname, exist_ok = True)

# Raises FileExistsError without the option
```