### PR TITLE
[ruby-on-rails] Update Bundler to 4.0.4

### DIFF
--- a/ruby-on-rails/Dockerfile
+++ b/ruby-on-rails/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update && apt-get install -y curl build-essential libpq-dev libvips 
 WORKDIR /tmp
 
 # Bundler
-RUN gem install bundler -v 4.0.3
+RUN gem update --system 4.0.4
+RUN gem install bundler -v 4.0.4
 
 WORKDIR /app
 

--- a/ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/Gemfile.lock
@@ -378,4 +378,4 @@ RUBY VERSION
   ruby 4.0.1
 
 BUNDLED WITH
-  4.0.3
+  4.0.4


### PR DESCRIPTION
## 1. References

- [Releases> bundler-v4.0.4](https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.4)
- [Comparing changes between 4.0.3 and 4.0.4](https://github.com/ruby/rubygems/compare/v4.0.3...bundler-v4.0.4)

## 2. Bundler 4.0.3 vs 4.0.4 Summary

### 2-1. Highlights

- Release contains 13 commits touching 35 files (per compare view) and is focused on CLI validation, Ruby compatibility, and cleanup safety.
- New changelog entries accompany the version bumps for both Bundler and RubyGems; internal lockfiles now pin Bundler 4.0.4.

### 2-2. Enhancements

1. `bundle add` validates option combinations (mutually exclusive `--git/--github`, `--branch` without a git source, etc.), preventing mis-specified dependency additions.
2. Bundler recognizes Ruby 4.1 platforms; CI matrices updated to Ruby 3.3.10, 3.4.8, and 4.0 to keep future interpreter support green.
3. Rubygems rebuild command sheds an unnecessary `require "date"`, and installer lazily `require "etc"` when calculating `make -j` worker counts with a safe fallback.

### 2-3. Bug Fixes

- Switching a gem with component dependencies (e.g., Rails) from Rubygems to git/path now promotes all components to the new source in the lockfile, avoiding mixed-source resolution bugs (PR #9213).
- `bundle clean` keeps the Bundler version currently running, so scripted environments don’t delete their own toolchain (PR #9221).
- `Bundler.rubygems.find_bundler` compares versions as strings to ensure the right gemspec is located even when version objects are passed.

### 2-4. Test & CI Updates

- Extensive specs added for the new `bundle add` validations and `bundle clean` behavior.
- New integration cases cover component gem migrations from Rubygems to git/path sources.
- All GitHub Actions workflows now use `ruby/setup-ruby@b90be12` (v1.279.0) and include Ruby 4.0 runners where applicable.

## 3. Commits

- [Update bundler to 4.0.4 on Dockerfile](https://github.com/hayat01sh1da/botpress-accuracy-checkers/commit/118025a4c7a5f96578b204c34b59c36efa94f964)
- [Fix bundler to the latest on Gemfile.lock](https://github.com/hayat01sh1da/botpress-accuracy-checkers/commit/762750fadb8f005fda7734df0f714bea67d13b2d)