### PR TITLE
Update bundle install on GHA configurations

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -61,7 +61,9 @@ jobs:
           bundler-cache: true
       - name: Install Gem Dependencies
         working-directory: ./ruby-on-rails
-        run: bundle install --path vendor/bundle
+        run: |
+          bundle config set --local path 'vendor/bundle'
+          bundle install
       - name: Run Brakeman
         working-directory: ./ruby-on-rails
         run: bundle exec brakeman --no-pager

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -61,7 +61,9 @@ jobs:
           bundler-cache: true
       - name: Install Gem Dependencies
         working-directory: ./ruby-on-rails
-        run: bundle install --path vendor/bundle
+        run: |
+          bundle config set --local path 'vendor/bundle'
+          bundle install
       - name: Run RSpec
         working-directory: ./ruby-on-rails
         run: bundle exec rspec


### PR DESCRIPTION
To resolve failure in `bundle install` as the following log shows.

```log
The `--path` flag has been removed because it relied on being remembered across
bundler invocations, which bundler no longer does. Instead please use `bundle
config set path 'vendor/bundle'`, and stop using this flag
Error: Process completed with exit code 15.
```