### PR TITLE
[ruby-on-rails] Update Rubygems and Bundler to 4.0.8

### DIFF
--- a/ruby-on-rails/Dockerfile
+++ b/ruby-on-rails/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update && apt-get install -y curl build-essential libpq-dev libvips 
 WORKDIR /tmp
 
 # Bundler
-RUN gem update --system 4.0.7 --no-document && \
-    gem install bundler -v 4.0.7 --no-document
+RUN gem update --system 4.0.8 --no-document && \
+    gem install bundler -v 4.0.8 --no-document
 
 WORKDIR /app
 


### PR DESCRIPTION
## 1. Summary

RubyGems and Bundler should be up to date for forward compatibility.

## 2. References
[RubyGems Org > Blog > 4.0.8 Released](https://blog.rubygems.org/2026/03/11/4.0.8-released.html)