### PR TITLE
Update Gemfile and Bundler to 4.0.9

### DIFF
--- a/ruby-on-rails/Dockerfile
+++ b/ruby-on-rails/Dockerfile
@@ -3,11 +3,13 @@ FROM ruby:4.0.2
 # Packages
 RUN apt-get update && apt-get install -y curl build-essential libpq-dev libvips libvips-dev vim tree
 
+ARG BUNDLER_VERSION=4.0.9
+
 WORKDIR /tmp
 
 # Bundler
-RUN gem update --system 4.0.9 --no-document && \
-    gem install bundler -v 4.0.9 --no-document
+RUN gem update --system ${BUNDLER_VERSION} --no-document && \
+    gem install bundler -v ${BUNDLER_VERSION} --no-document
 
 WORKDIR /app
 

--- a/ruby-on-rails/Dockerfile
+++ b/ruby-on-rails/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update && apt-get install -y curl build-essential libpq-dev libvips 
 WORKDIR /tmp
 
 # Bundler
-RUN gem update --system 4.0.8 --no-document && \
-    gem install bundler -v 4.0.8 --no-document
+RUN gem update --system 4.0.9 --no-document && \
+    gem install bundler -v 4.0.9 --no-document
 
 WORKDIR /app
 

--- a/ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/Gemfile.lock
@@ -380,4 +380,4 @@ RUBY VERSION
   ruby 4.0.2
 
 BUNDLED WITH
-  4.0.8
+  4.0.9


### PR DESCRIPTION
> **Release tag:** [bundler-v4.0.9](https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.9)
> **Full diff:** [v4.0.8...bundler-v4.0.9](https://github.com/ruby/rubygems/compare/v4.0.8...bundler-v4.0.9)
> **Released by:** [@hsbt](https://github.com/hsbt) (commit `3ce4a32`)

---

## 1. Enhancements

### 1-1. Split the download and install process of a gem ([#9381](https://github.com/ruby/rubygems/pull/9381))

- **Author:** Edouard-chin (Shopify)
- **Problem:** Bundler previously waited for a gem's dependencies to be both downloaded *and* installed before proceeding to download/install the gem itself. This created a bottleneck where only a single thread was doing work at the end of the installation process.
- **Solution:** The download phase is now decoupled from the install phase:
  1. All gems are downloaded without dependency checks.
  2. Pure Ruby gems are installed immediately after download, with no dependency wait.
  3. Gems with native extensions still wait for their dependencies to be installed before compilation (since `extconf.rb` may require them).
  4. If a native extension gem's dependencies aren't ready yet, it is re-queued for later.
- **Impact:** Improved parallelisation of `bundle install`. The speed gain depends on the depth of the dependency tree. Also paves the way for a future `bundle download` feature ([#9138](https://github.com/ruby/rubygems/issues/9138)).

### 1-2. Introduce a priority queue ([#9389](https://github.com/ruby/rubygems/pull/9389))

- **Author:** Edouard-chin (Shopify)
- **Problem:** "Tail latency" — gems with native extensions that end up at the back of the install queue delay the overall `bundle install`, since compilation is the slowest part.
- **Solution:** A priority queue is introduced. When a downloaded gem has a native extension *and* its dependencies are already installed, it is placed in the priority queue so a worker picks it up as early as possible.
- **Impact:** Reduces tail latency by starting native extension compilation sooner. Benchmarks showed around ~13% speed-up on a freshly generated Rails application, though actual gains vary by machine and dependency tree.

### 1-3. Normalise the number of workers for parallel operations ([#9400](https://github.com/ruby/rubygems/pull/9400))

- **Author:** Edouard-chin (Shopify)
- **Problem:** The number of worker threads used for parallel downloads was hardcoded to 5, which was originally chosen out of caution about hammering RubyGems.org. Since downloads go through the Fastly CDN (not directly to RubyGems.org servers), the concern was no longer valid.
- **Solution:** The worker count for downloads now respects the `BUNDLE_JOBS` configuration (defaulting to `Etc.nprocessors`), aligning it with the parallelism used for installation.
- **Impact:** Faster gem downloads, especially on machines with many CPU cores. The `bundle config` man page was updated accordingly.

### 1-4. Check the git version only once per `bundle install` ([#9406](https://github.com/ruby/rubygems/pull/9406))

- **Author:** Edouard-chin (Shopify)
- **Problem:** For each git gem in a Gemfile, a new `Git` source object was created, and each one made a system call to check the installed git version. Each call cost ~50ms, adding up for Gemfiles with many git sources.
- **Solution:** The git version is now memoised at the class level, so only a single `git --version` system call is made per `bundle install` run.
- **Impact:** Eliminates ~50ms of overhead per git gem source in the Gemfile.

### 1-5. Add exponential backoff to bundler retries ([#9163](https://github.com/ruby/rubygems/pull/9163))

- **Author:** ChrisBr (Shopify)
- **Problem:** Bundler's retry mechanism used fixed delays, which is suboptimal for transient network failures (e.g. rate-limiting, server overload). Closes [#5361](https://github.com/ruby/rubygems/issues/5361).
- **Solution:** Retries now use exponential backoff with jitter:
  ```
  Attempt 1: Initial try (no delay)
     ↓ fails
     Wait: 1.0 – 1.5 seconds (1.0s base + 0–0.5s jitter)
     ↓
  Attempt 2: First retry
     ↓ fails
     Wait: 2.0 – 2.5 seconds (2.0s base + 0–0.5s jitter)
     ↓
  Attempt 3: Second retry
  ```
- **Impact:** More resilient network operations with reduced risk of overwhelming a recovering server.

---

## 2. Bug Fixes

### 2-1. Retry git fetch without `--depth` for dumb HTTP transport ([#9405](https://github.com/ruby/rubygems/pull/9405))

- **Author:** hsbt
- **Problem:** Dumb HTTP git servers do not support shallow clone capabilities. Bundler already had a fallback for `git clone` (retrying without `--depth`), but the same fallback was missing for `git fetch`, causing `bundle install` to fail when fetching updates. Fixes [#9001](https://github.com/ruby/rubygems/issues/9001) and [#9049](https://github.com/ruby/rubygems/pull/9049).
- **Solution:**
  - Refactored git command assembly into `fetch_command` / `clone_command` helpers.
  - Extended the existing shallow-clone fallback to also apply to shallow fetches — when a shallow fetch fails, Bundler now retries without `--depth`.
  - Renamed `full_clone?` to `shallow?` for clarity.
- **Impact:** `bundle install` now works correctly with dumb HTTP git sources that don't support shallow fetches.

---

## 3. Summary Table

| Category | PR | Title | Author |
|---|---|---|---|
| Enhancement | [#9381](https://github.com/ruby/rubygems/pull/9381) | Split download and install process | Edouard-chin |
| Enhancement | [#9389](https://github.com/ruby/rubygems/pull/9389) | Introduce a priority queue | Edouard-chin |
| Enhancement | [#9400](https://github.com/ruby/rubygems/pull/9400) | Normalise parallel worker count | Edouard-chin |
| Enhancement | [#9406](https://github.com/ruby/rubygems/pull/9406) | Check git version only once | Edouard-chin |
| Enhancement | [#9163](https://github.com/ruby/rubygems/pull/9163) | Exponential backoff for retries | ChrisBr |
| Bug fix | [#9405](https://github.com/ruby/rubygems/pull/9405) | Retry git fetch without `--depth` | hsbt |