### PR TITLE
[ruby-on-rails] Update nokogiri and json to the Latest Version

### DIFF
--- a/ruby-on-rails/Gemfile
+++ b/ruby-on-rails/Gemfile
@@ -12,7 +12,7 @@ gem 'sprockets-rails', '~> 3.5.2'
 
 gem 'dotenv-rails', '~> 3.2.0'
 
-gem 'nokogiri', '~> 1.19.1'
+gem 'nokogiri', '~> 1.19.2'
 
 gem 'rexml', '~> 3.4.4'
 

--- a/ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.19.2)
+    json (2.19.3)
     listen (3.10.0)
       logger
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -143,10 +143,10 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.1)
+    nokogiri (1.19.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.19.1-x86_64-linux-gnu)
+    nokogiri (1.19.2-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.3)
     pp (0.6.3)
@@ -267,7 +267,7 @@ DEPENDENCIES
   dotenv-rails (~> 3.2.0)
   ffi (~> 1.17.2)
   listen (~> 3.10.0)
-  nokogiri (~> 1.19.1)
+  nokogiri (~> 1.19.2)
   ostruct (~> 0.6.3)
   puma (~> 7.2.0)
   rack-mini-profiler (~> 4.0.1)
@@ -316,7 +316,7 @@ CHECKSUMS
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
-  json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
+  json (2.19.3) sha256=289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
@@ -331,8 +331,8 @@ CHECKSUMS
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
-  nokogiri (1.19.1) sha256=598b327f36df0b172abd57b68b18979a6e14219353bca87180c31a51a00d5ad3
-  nokogiri (1.19.1-x86_64-linux-gnu) sha256=1a4902842a186b4f901078e692d12257678e6133858d0566152fe29cdb98456a
+  nokogiri (1.19.2) sha256=38fdd8b59db3d5ea9e7dfb14702e882b9bf819198d5bf976f17ebce12c481756
+  nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193


### PR DESCRIPTION
## 1. Gem Changes

| Gem | Before | After |
|---|---|---|
| **nokogiri** | 1.19.1 | 1.19.2 |
| **json** | 2.19.2 | 2.19.3 |

---

## 2. nokogiri 1.19.1 → 1.19.2

- **[JRuby] Saxon-HE dependency updated** from 9.6.0-4 to 12.7. Saxon-HE is a transitive dependency of `nu.validator:jing`. This update addresses CVEs in Saxon-HE's own transitive dependencies (JDOM and dom4j). The maintainers didn't consider it severe enough for a security release, but cut a patch to help users whose security scanners were flagging it. ([#3611](https://github.com/sparklemotion/nokogiri/issues/3611))

## 3. json 2.19.2 → 2.19.3

- **Fix handling of unescaped control characters preceded by a backslash.** This is a parsing bug fix — certain input containing a backslash followed by an unescaped control character was not handled correctly. ([full diff](https://github.com/ruby/json/compare/v2.19.2...v2.19.3))

---

## 4. Files Changed

- **ruby-on-rails/Gemfile** — `nokogiri` version constraint bumped from `~> 1.19.1` to `~> 1.19.2`.
- **ruby-on-rails/Gemfile.lock** — `nokogiri` (source + `x86_64-linux-gnu`) updated to 1.19.2; `json` updated to 2.19.3; SHA256 checksums updated for all affected entries.