### PR TITLE
[ruby-on-rails] Bump Puma to 8.0.0

### DIFF
--- a/ruby-on-rails/Gemfile
+++ b/ruby-on-rails/Gemfile
@@ -6,7 +6,7 @@ ruby file: '.ruby-version'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 8.1.3'
 # Use Puma as the app server
-gem 'puma', '~> 7.2.0'
+gem 'puma', '~> 8.0.0'
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails', '~> 3.5.2'
 

--- a/ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
     psych (5.3.1)
       date
       stringio
-    puma (7.2.0)
+    puma (8.0.0)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -260,7 +260,7 @@ DEPENDENCIES
   ffi (~> 1.17.4)
   nokogiri (~> 1.19.2)
   ostruct (~> 0.6.3)
-  puma (~> 7.2.0)
+  puma (~> 8.0.0)
   rack-mini-profiler (~> 4.0.1)
   rails (~> 8.1.3)
   rexml (~> 3.4.4)
@@ -327,7 +327,7 @@ CHECKSUMS
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
-  puma (7.2.0) sha256=bf8ef4ab514a4e6d4554cb4326b2004eba5036ae05cf765cfe51aba9706a72a8
+  puma (8.0.0) sha256=1681050b8b60fab1d3033255ab58b6aec64cd063e43fc6f8204bcb8bf9364b88
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
   rack-mini-profiler (4.0.1) sha256=485810c23211f908196c896ea10cad72ed68780ee2998bec1f1dfd7558263d78


### PR DESCRIPTION
## 1. Overview

| | **Puma 7.2.0** | **Puma 8.0.0** |
|---|---|---|
| **Release Date** | 2026-01-20 | 2026-03-27 |
| **Codename** | On The Corner | Into the Arena |
| **Type** | Minor release | Major release (breaking changes) |

## 2. Breaking Changes (8.0.0 only)

- **Default production bind address changed** from `0.0.0.0` (IPv4) to `::` (IPv6) when a non-loopback IPv6 interface is available; falls back to `0.0.0.0` if IPv6 is unavailable ([#3847](https://github.com/puma/puma/pull/3847))

## 3. Features

### 3-1. Puma 7.2.0

- Add workers `:auto` ([#3827](https://github.com/puma/puma/pull/3827))
- Make it possible to restrict control server commands to stats ([#3787](https://github.com/puma/puma/pull/3787))

### 3-2. Puma 8.0.0

- Add `env["puma.mark_as_io_bound"]` API and `max_io_threads` config to allow IO-bound requests to exceed the thread pool max, enabling better handling of mixed workloads ([#3816](https://github.com/puma/puma/pull/3816), [#3894](https://github.com/puma/puma/pull/3894))
- Add `single` and `cluster` DSL hooks for mode-specific configuration ([#3621](https://github.com/puma/puma/pull/3621))
- Add `on_force` option to `shutdown_debug` to only dump thread backtraces on forced (non-graceful) shutdown ([#3671](https://github.com/puma/puma/pull/3671))
- Add API to dynamically update min and max thread counts at runtime via `update_thread_pool_min_max` and `ServerPluginControl` ([#3658](https://github.com/puma/puma/pull/3658))
- Use SIGPWR for thread backtrace dumps on Linux/JRuby where SIGINFO is unavailable ([#3829](https://github.com/puma/puma/pull/3829))

## 4. Bugfixes

### 4-1. Puma 7.2.0

- Don't break if `WEB_CONCURRENCY` is set to a blank string ([#3837](https://github.com/puma/puma/pull/3837))
- Don't share server between worker 0 and descendants on refork ([#3602](https://github.com/puma/puma/pull/3602))
- Fix phase check race condition in `Puma::Cluster#check_workers` ([#3690](https://github.com/puma/puma/pull/3690))
- Fix advertising of CLI config before config files are loaded ([#3823](https://github.com/puma/puma/pull/3823))

### 4-2. Puma 8.0.0

- Fix phased restart for `fork_worker` to avoid forking from stale worker 0 when it has been replaced ([#3853](https://github.com/puma/puma/pull/3853))

## 5. Performance

### 5-1. Puma 7.2.0

- 17% faster HTTP parsing through pre-interning env keys ([#3825](https://github.com/puma/puma/pull/3825))
- Implement `dsize` and `dcompact` functions for `Puma::HttpParser`, making Puma's C-extension GC-compactible ([#3828](https://github.com/puma/puma/pull/3828))

### 5-2. Puma 8.0.0

- JRuby HTTP parser improvements: pre-allocated header keys, perfect hash lookup, reduced memory copies ([#3838](https://github.com/puma/puma/pull/3838))
- Cache downcased header key in `str_headers` to avoid redundant `String#downcase` calls, reducing allocations by ~50% per response ([#3874](https://github.com/puma/puma/pull/3874))

## 6. Refactor

### 6-1. Puma 7.2.0

- Remove `NoMethodError` rescue in `Reactor#select_loop` ([#3831](https://github.com/puma/puma/pull/3831))
- Various cleanups in the C extension ([#3814](https://github.com/puma/puma/pull/3814))
- Monomorphize `handle_request` return ([#3802](https://github.com/puma/puma/pull/3802))

### 6-2. Puma 8.0.0

- Collect `env` processing into dedicated `client_env.rb` module ([#3582](https://github.com/puma/puma/pull/3582))
- Move event to default configuration ([#3872](https://github.com/puma/puma/pull/3872))

## 7. Docs

### 7-1. Puma 7.2.0

- Change link to `docs/deployment.md` in `README.md` ([#3848](https://github.com/puma/puma/pull/3848))
- Fix formatting for each signal description in signals.md ([#3813](https://github.com/puma/puma/pull/3813))
- Update deployment and Kubernetes docs with Puma configuration tips ([#3807](https://github.com/puma/puma/pull/3807))
- Rename master to main ([#3809](https://github.com/puma/puma/pull/3809), [#3808](https://github.com/puma/puma/pull/3808), [#3800](https://github.com/puma/puma/pull/3800))
- Fix some minor typos in the docs ([#3804](https://github.com/puma/puma/pull/3804))
- Add `GOVERNANCE.md`, `MAINTAINERS` ([#3826](https://github.com/puma/puma/pull/3826))
- Remove Code Climate badge ([#3820](https://github.com/puma/puma/pull/3820))
- Add @joshuay03 to the maintainer list

### 7-2. Puma 8.0.0

- Add gRPC guide for configuring gRPC lifecycle hooks in clustered mode ([#3885](https://github.com/puma/puma/pull/3885))
- Add 7.0 upgrade guide, move 5.0/6.0 upgrade guides to docs directory ([#3900](https://github.com/puma/puma/pull/3900))
- Correct default values for `persistent_timeout` and `worker_boot_timeout` in DSL docs ([#3912](https://github.com/puma/puma/pull/3912))
- Add file descriptor limit warning in test helper for contributors ([#3893](https://github.com/puma/puma/pull/3893))

## 8. CI (7.2.0 only)

- Use Minitest 6 where applicable ([#3859](https://github.com/puma/puma/pull/3859))
- Many test suite improvements and flake fixes ([#3861](https://github.com/puma/puma/pull/3861), [#3863](https://github.com/puma/puma/pull/3863), [#3860](https://github.com/puma/puma/pull/3860), [#3852](https://github.com/puma/puma/pull/3852), [#3857](https://github.com/puma/puma/pull/3857), [#3856](https://github.com/puma/puma/pull/3856), [#3845](https://github.com/puma/puma/pull/3845), [#3843](https://github.com/puma/puma/pull/3843), [#3842](https://github.com/puma/puma/pull/3842), [#3841](https://github.com/puma/puma/pull/3841), [#3822](https://github.com/puma/puma/pull/3822))

## 9. Key Takeaways

1. **8.0.0 is a major version** with a breaking change to the default bind address (IPv6 by default in production). Review the [8.0 Upgrade Guide](https://github.com/puma/puma/blob/main/docs/8.0-Upgrade.md) before upgrading.
2. **IO-bound workload support** is the headline feature of 8.0.0 — `puma.mark_as_io_bound` and `max_io_threads` let IO-heavy requests exceed the normal thread pool cap.
3. **Runtime thread tuning** is now possible in 8.0.0 via `update_thread_pool_min_max`.
4. **7.2.0 focused on stability and parsing speed**, with a notable 17% HTTP parsing speedup and GC-compaction support for the C extension.
5. Both releases include meaningful **JRuby and performance improvements**.