### PR TITLE
[python] Introduce Mypy Typechecking

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
+          pip install flake8 mypy pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |
@@ -41,6 +41,9 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Typecheck with mypy
+        working-directory: ./python
+        run: mypy .
       - name: Run UnitTest
         working-directory: ./python
         run: bash run_unittests.sh

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.mypy]
+python_version = "3.14"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true

--- a/python/src/accuracy_check.py
+++ b/python/src/accuracy_check.py
@@ -7,7 +7,7 @@ from accuracy_check_query import AccuracyCheckQuery
 from chart_drawer import ChartDrawer
 
 class AccuracyCheck:
-    def __init__(self, scheme, host, bot_id, user_id, test_data):
+    def __init__(self, scheme: str, host: str, bot_id: str, user_id: str, test_data: str) -> None:
         self.scheme               = scheme
         self.host                 = host
         self.bot_id               = bot_id
@@ -17,11 +17,11 @@ class AccuracyCheck:
         self.res_bodies           = self.accuracy_check_query.res_bodies()
         self.chart_drawer         = ChartDrawer(self.test_data, self.res_bodies)
 
-    def export_chart(self, dirname):
+    def export_chart(self, dirname: str) -> None:
         with open(self.__filename__(dirname), 'w') as f:
             self.chart_drawer.csv(f)
 
     # private
 
-    def __filename__(self, dirname):
+    def __filename__(self, dirname: str) -> str:
         return os.path.join(dirname, f'accuracy_score_chart_{datetime.datetime.now():%Y%m%d%H%M%S}.csv')

--- a/python/src/lib/chart_drawer.py
+++ b/python/src/lib/chart_drawer.py
@@ -1,9 +1,10 @@
 import csv
 import json
+from typing import Any, TextIO
 from list_handler import __csv_to_dicts__
 
 class ChartDrawer:
-    def __init__(self, test_data, res_bodies):
+    def __init__(self, test_data: str, res_bodies: list[dict[str, Any]]) -> None:
         self.test_data  = __csv_to_dicts__(test_data)
         self.res_bodies = res_bodies
         self.ids        = [test_datum['ID'] for test_datum in self.test_data]
@@ -11,7 +12,7 @@ class ChartDrawer:
         self.answers    = [test_datum['Answer'] for test_datum in self.test_data]
         self.header     = ['ID', 'Test_Data'] + self.ids
 
-    def csv(self, f):
+    def csv(self, f: TextIO) -> None:
         writer = csv.writer(f)
         writer.writerow(self.header)
         i = 0
@@ -21,7 +22,7 @@ class ChartDrawer:
 
     # private
 
-    def __score_tables__(self):
+    def __score_tables__(self) -> list[list[dict[str, float]]]:
         score_tables = list()
         for res_body in self.res_bodies:
             _score_tables = list()
@@ -34,7 +35,7 @@ class ChartDrawer:
             score_tables.append(_score_tables)
         return score_tables
 
-    def __rows__(self):
+    def __rows__(self) -> list[list[str]]:
         rows = list()
         for s_tables in self.__score_tables__():
             scores  = list()

--- a/python/src/lib/format.py
+++ b/python/src/lib/format.py
@@ -1,8 +1,9 @@
 import csv
 import json
+from typing import Any
 from list_handler import __uniq_list__
 
-def __template__():
+def __template__() -> dict[str, Any]:
     return {
         'id': '',
         'data': {
@@ -20,7 +21,7 @@ def __template__():
         }
     }
 
-def __to_json__(csv_training_data):
+def __to_json__(csv_training_data: str) -> str:
     result = list()
     format = __template__()
 

--- a/python/src/lib/list_handler.py
+++ b/python/src/lib/list_handler.py
@@ -1,13 +1,13 @@
 import csv
 
-def __uniq_list__(data):
+def __uniq_list__(data: list) -> list:
     result = list()
     for datum in data:
         if not datum in result:
             result.append(datum)
     return result
 
-def __csv_to_dicts__(csv_file):
+def __csv_to_dicts__(csv_file: str) -> list[dict[str, str]]:
     data = None
     with open(csv_file) as f:
         reader = csv.DictReader(f)

--- a/python/src/queries/accuracy_check_query.py
+++ b/python/src/queries/accuracy_check_query.py
@@ -2,12 +2,13 @@ import urllib.request
 import json
 import os
 import re
+from typing import Any
 from list_handler import __csv_to_dicts__
 
 INVALID_PATTERNS = r'[\\\'\|\`\^\"\<\>\)\(\}\{\]\[\;\/\?\:\@\&\=\+\$\,\%\# ]'
 
 class AccuracyCheckQuery:
-    def __init__(self, scheme, host, bot_id, user_id, test_data):
+    def __init__(self, scheme: str, host: str, bot_id: str, user_id: str, test_data: str) -> None:
         self.scheme    = re.sub(INVALID_PATTERNS, '', scheme)
         self.host      = re.sub(INVALID_PATTERNS, '', host)
         self.bot_id    = re.sub(INVALID_PATTERNS, '', bot_id)
@@ -15,12 +16,12 @@ class AccuracyCheckQuery:
         self.test_data = __csv_to_dicts__(test_data)
         self.uri       = f'{self.scheme}://{self.host}/api/v1/bots/{self.bot_id}/converse/{self.user_id}/secured?include=suggestions'
 
-    def res_bodies(self):
+    def res_bodies(self) -> list[dict[str, Any]]:
         return [json.loads(res_body.read()) for res_body in self.__request__()]
 
     # private
 
-    def __request__(self):
+    def __request__(self) -> list[Any]:
         responses = list()
         for test_datum in self.test_data:
             header = {

--- a/python/src/training_data.py
+++ b/python/src/training_data.py
@@ -5,14 +5,14 @@ sys.path.append('./src/lib')
 from format import __to_json__
 
 class TrainingData:
-    def __init__(self, training_data):
+    def __init__(self, training_data: str) -> None:
         self.training_data = training_data
 
-    def export(self, dirname):
+    def export(self, dirname: str) -> None:
         with open(self.__filename__(dirname), 'w') as f:
             f.write(__to_json__(self.training_data))
 
     # private
 
-    def __filename__(self, dirname):
+    def __filename__(self, dirname: str) -> str:
         return os.path.join(dirname, f'training_data_{datetime.datetime.now():%Y%m%d%H%M%S}.json')

--- a/python/test/lib/test_chart_drawer.py
+++ b/python/test/lib/test_chart_drawer.py
@@ -10,7 +10,7 @@ from list_handler import __csv_to_dicts__
 from test_application import TestApplication
 
 class TestChartDrawer(TestApplication):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.csv_path   = os.path.join('..', 'csv', 'test_data.csv')
         json_path       = os.path.join('..', 'json', 'res_bodies.json')
@@ -19,7 +19,7 @@ class TestChartDrawer(TestApplication):
             self.res_bodies = json.loads(f.read())
         self.chart_drawer = ChartDrawer(self.csv_path, self.res_bodies)
 
-    def test_csv(self):
+    def test_csv(self) -> None:
         filename = os.path.join(self.dirname, f'accuracy_score_chart_{datetime.datetime.now():%Y%m%d%H%M%S}.csv')
         with open(filename, 'w') as f:
             self.chart_drawer.csv(f)

--- a/python/test/test_application.py
+++ b/python/test/test_application.py
@@ -4,12 +4,12 @@ import shutil
 import glob
 
 class TestApplication(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.dirname  = os.path.join('test', 'tmp')
         self.pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
         os.makedirs(self.dirname, exist_ok = True)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         if os.path.exists(self.dirname):
             shutil.rmtree(self.dirname)
         for pycache in self.pycaches:

--- a/python/test/test_training_data.py
+++ b/python/test/test_training_data.py
@@ -7,12 +7,12 @@ from training_data import TrainingData
 from test_application import TestApplication
 
 class TestTrainingData(TestApplication):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         training_data = os.path.join('..', 'csv', 'training_data.csv')
         self.training_data = TrainingData(training_data)
 
-    def test_export(self):
+    def test_export(self) -> None:
         self.training_data.export(self.dirname)
         self.assertTrue(any(glob.glob(f'{self.dirname}/training_data*.json')))
 


### PR DESCRIPTION
## 1. Why (Purpose)

### 1-1. Reliability

- Static type checking catches type-related bugs at development time before they reach production
- Enforcing `disallow_untyped_defs = true` ensures every function signature is explicitly typed, eliminating ambiguity
- `warn_return_any = true` prevents unintentionally returning loosely-typed values, reducing runtime surprises

### 1-2. Maintainability

- Type annotations serve as living documentation, clarifying expected inputs/outputs for each function and method
- Explicit parameter and return types make it easier for future contributors to understand and modify code confidently
- CI-integrated typechecking guarantees type correctness is maintained throughout the project lifecycle

## 2. What (Procedures)

### 2-1. Target Repositories (13 repos)

| # | Repository | Files Changed | Insertions | Deletions |
|---|------------|---------------|------------|-----------|
| 1 | botpress-accuracy-checkers | 11 | +35 | -24 |
| 2 | coding-tests | 16 | +60 | -41 |
| 3 | deep-learnings | 1-9 | +9-0 | -7-9 |
| 4 | file-cleaners | 4 | +31 | -23 |
| 5 | file-extension-converters | 5 | +39 | -31 |
| 6 | github-wiki-organisers | 12 | +1-2 | -1-4 |
| 7 | itunes-file-delimiter-replacer | 5 | +40 | -32 |
| 8 | json-data-sorters | 4 | +30 | -20 |
| 9 | natural-language-processing | 7 | +91 | -77 |
| 10 | pr-title-printers | 4 | +17 | -9 |
| 11 | template-creators | 4 | +32 | -24 |
| 12 | tutorials | 36 | +1-3 | -1-5 |
| 13 | web-scrapers | 14 | +65 | -56 |

### 2-2. Mypy Configuration (`pyproject.toml`)

A `pyproject.toml` was created (or updated if it already existed) with the following `[tool.mypy]` section, consistent across all 13 repositories:

```toml
[tool.mypy]
python_version = "3-14"
warn_return_any = true
warn_unused_configs = true
disallow_untyped_defs = true
```

- **`python_version`** — Targets Python 3-14
- **`warn_return_any`** — Warns when a function returns a value typed as `Any`
- **`warn_unused_configs`** — Warns about unused `[tool.mypy]` config entries
- **`disallow_untyped_defs`** — Rejects function definitions without type annotations (the strictest baseline)

### 2-3. Type Annotations Added to Source and Test Files

- **Function parameters**: Added type annotations to all parameters (e.g., `def __init__(self, scheme: str, host: str, bot_id: str, ...) -> None:`)
- **Return types**: Added return type annotations to all functions/methods (e.g., `-> str`, `-> None`, `-> list[dict[str, Any]]`)
- **`from typing import`**: Used `Any`, `TextIO`, etc. from the `typing` module where Python built-in types were insufficient (mainly in botpress-accuracy-checkers, deep-learnings, json-data-sorters, natural-language-processing, web-scrapers)
- **`from __future__ import annotations`**: Used in coding-tests and deep-learnings for forward-compatible union type syntax (e.g., `int | str`)
- **Test methods**: All `setUp()`, `tearDown()`, and `test_*()` methods annotated with `-> None`

### 2-4. GitHub Actions Workflow Updates

The CI pipeline was updated to include a mypy typechecking step in the existing GHA workflow files:

1. **Dependency installation** — Added `mypy` to `pip install` alongside `flake8` and `pytest`:

   ```yaml
   pip install flake8 mypy pytest
   ```

2. **Typecheck step** — Inserted a new `Typecheck with mypy` step between flake8 linting and unit test execution:

   ```yaml
   - name: Typecheck with mypy
     working-directory: ./python  # where applicable
     run: mypy .
   ```

   - For repos with a `python/` subdirectory (most repos): `working-directory: ./python` was specified
   - For repos where Python is at root level (web-scrapers, deep-learnings, natural-language-processing): `mypy .` runs from the repo root
   - deep-learnings has 3 separate workflow files (`vol1.yml`, `vol2.yml`, `vol3.yml`), each updated with the mypy step

## 3. How (Operation and Maintenance)

### 3-1. Automatic Enforcement via CI

- Mypy runs on every push and pull request via GitHub Actions
- The step is placed **after flake8 linting** and **before unit tests**, so type errors are caught early in the pipeline
- Any type errors will cause the CI pipeline to fail, blocking the merge

### 3-2. Day-to-Day Development

- When adding new functions/methods, type annotations are required — mypy rejects untyped definitions (`disallow_untyped_defs = true`)
- When modifying existing function signatures, type annotations must be updated accordingly
- Run `mypy .` locally before pushing to catch issues early

### 3-3. Updating Configuration

- Mypy settings are centralised in `pyproject.toml` at the Python project root
- When upgrading the Python version, update `python_version` in `pyproject.toml`

## 4. Pros & Cons

### 4-1. Pros

- **Early bug detection**: Type mismatches are caught at static analysis time, not at runtime
- **Self-documenting code**: Type annotations make function contracts explicit without extra comments
- **CI-enforced quality gate**: Prevents type regressions from being merged
- **Minimal configuration**: A single 5-line `[tool.mypy]` block in `pyproject.toml` covers the entire project
- **Zero runtime overhead**: Mypy is a static analyser only — no performance impact on production code
- **Gradual adoption**: Can be introduced incrementally; existing untyped code can be annotated file by file

### 4-2. Cons

- **Initial effort**: All existing function signatures must be annotated upfront (1-9 files changed in deep-learnings alone)
- **Learning curve**: Developers unfamiliar with Python type hints need to learn `typing` module constructs (`Any`, `TextIO`, union types, etc.)
- **Third-party library stubs**: Some libraries lack type stubs, potentially requiring `type: ignore` comments or stub packages
- **Increased verbosity**: Type annotations add visual noise to otherwise concise Python code
- **Maintenance cost**: Signature changes require updating type annotations in tandem, adding friction to refactoring