### PR TITLE
[ruby] Introduce Rubocop for Static Code Analysis

### DIFF
--- a/.github/workflows/ruby-on-rails.yml
+++ b/.github/workflows/ruby-on-rails.yml
@@ -70,3 +70,6 @@ jobs:
       - name: Run Brakeman
         working-directory: ./ruby-on-rails
         run: bundle exec brakeman --no-pager
+      - name: Run RuboCop
+        working-directory: ./ruby-on-rails
+        run: bundle exec rubocop

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,6 +34,11 @@ jobs:
       # change this to (see https://github.com/ruby/setup-ruby#versioning):
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
+      - name: Install Gems
+        run: gem install rubocop rubocop-minitest rubocop-performance
       - name: Run Minitest
         working-directory: ./ruby
         run: rake
+      - name: Run RuboCop
+        working-directory: ./ruby
+        run: rubocop

--- a/ruby-on-rails/.rubocop.yml
+++ b/ruby-on-rails/.rubocop.yml
@@ -1,0 +1,15 @@
+# Reference: https://github.com/rubocop/ruby-style-guide
+
+require:
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-rspec
+
+AllCops:
+  TargetRubyVersion: 4.0
+  NewCops: enable
+  Exclude:
+    - 'bin/**/*'
+    - 'db/schema.rb'
+    - 'vendor/**/*'
+    - 'node_modules/**/*'

--- a/ruby-on-rails/Gemfile
+++ b/ruby-on-rails/Gemfile
@@ -45,6 +45,11 @@ group :development do
   gem 'rack-mini-profiler', '~> 4.0.1'
   # Static code analysis for security vulnerabilities
   gem 'brakeman', '~> 8.0.4', require: false
+  # RuboCop
+  gem 'rubocop', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
+  gem 'rubocop-rspec', require: false
 end
 
 group :test do

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,0 +1,9 @@
+# Reference: https://github.com/rubocop/ruby-style-guide
+
+require:
+  - rubocop-minitest
+  - rubocop-performance
+
+AllCops:
+  TargetRubyVersion: 4.0
+  NewCops: enable

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+ruby file: '../.ruby-version'
+
+gem 'rubocop', require: false
+gem 'rubocop-minitest', require: false
+gem 'rubocop-performance', require: false


### PR DESCRIPTION
## 1. Why (Purpose)

RuboCop has been introduced across all Ruby and Rails projects to improve **reliability** and **maintainability** by enforcing consistent coding standards based on the community-driven [Ruby Style Guide](https://github.com/rubocop/ruby-style-guide). Static code analysis catches style violations, potential bugs, and performance issues early — before code reaches production — reducing review burden and keeping the codebase uniform regardless of contributor.

## 2. What (Procedures)

### 2-1. Target Projects

RuboCop was applied to **13 projects** across **10 repositories**.

#### 2-1-1. Pure Ruby Projects (9 projects)

| # | Repository | Sub-path | Test Framework |
|---|-----------|----------|----------------|
| 1 | botpress-accuracy-checkers | `ruby/` | Minitest |
| 2 | coding-tests | `ruby/` | Minitest |
| 3 | file-cleaners | `ruby/` | Minitest |
| 4 | file-extension-converters | `ruby/` | Minitest |
| 5 | github-wiki-organisers | `ruby/` | Minitest |
| 6 | itunes-file-delimiter-replacer | `ruby/` | Minitest |
| 7 | json-data-sorters | `ruby/` | Minitest |
| 8 | pr-title-printers | `ruby/` | Minitest |
| 9 | template-creators | `ruby/` | Minitest |

#### 2-1-2. Rails Projects (4 projects)

| # | Repository | Sub-path | Test Framework |
|---|-----------|----------|----------------|
| 1 | botpress-accuracy-checkers | `ruby-on-rails/` | RSpec |
| 2 | tutorials | `ruby-on-rails/restful-api/` | RSpec |
| 3 | tutorials | `ruby-on-rails/perfect-ruby-on-rails/` | Minitest |
| 4 | tutorials | `ruby-on-rails/e-navigator/` | Minitest |

### 2-2. Changes Made

Each repository was branched and committed with **3 semantic commits**:

#### 2-2-1. Add RuboCop Gems to Gemfile

**Pure Ruby projects** — Created `ruby/Gemfile` with:

```ruby
gem 'rubocop', require: false
gem 'rubocop-minitest', require: false
gem 'rubocop-performance', require: false
```

**Rails projects (RSpec)** — Added to the `:development` group after `brakeman`:

```ruby
gem 'rubocop', require: false
gem 'rubocop-performance', require: false
gem 'rubocop-rails', require: false
gem 'rubocop-rspec', require: false
```

**Rails projects (Minitest)** — Added to the `:development` group after `brakeman`:

```ruby
gem 'rubocop', require: false
gem 'rubocop-minitest', require: false
gem 'rubocop-performance', require: false
gem 'rubocop-rails', require: false
```

#### 2-2-2. Add `.rubocop.yml`

**Pure Ruby projects** — `ruby/.rubocop.yml`:

```yaml
require:
  - rubocop-minitest
  - rubocop-performance

AllCops:
  TargetRubyVersion: 4.0
  NewCops: enable
```

**Rails projects (RSpec)** — `.rubocop.yml`:

```yaml
require:
  - rubocop-performance
  - rubocop-rails
  - rubocop-rspec

AllCops:
  TargetRubyVersion: 4.0
  NewCops: enable
  Exclude:
    - 'bin/**/*'
    - 'db/schema.rb'
    - 'vendor/**/*'
    - 'node_modules/**/*'
```

**Rails projects (Minitest)** — `.rubocop.yml`:

```yaml
require:
  - rubocop-minitest
  - rubocop-performance
  - rubocop-rails

AllCops:
  TargetRubyVersion: 4.0
  NewCops: enable
  Exclude:
    - 'bin/**/*'
    - 'db/schema.rb'
    - 'vendor/**/*'
    - 'node_modules/**/*'
```

#### 2-2-3. Add RuboCop Step to CI Workflow

**Pure Ruby projects** — Added to `.github/workflows/ruby.yml`:

```yaml
- name: Install Gems
  run: gem install rubocop rubocop-minitest rubocop-performance
- name: Run RuboCop
  working-directory: ./ruby
  run: rubocop
```

**Rails projects** — Added after the `Run Brakeman` step in each workflow:

```yaml
- name: Run RuboCop
  working-directory: ./<project-path>
  run: bundle exec rubocop
```

### 2-3. Git Operations

| Item | Value |
|------|-------|
| Branch | `ruby/introduce-rubocop-to-app` |
| Commits per repo | 3 |
| Commit 1 | `Add RuboCop gems to Gemfile` |
| Commit 2 | `Add .rubocop.yml` |
| Commit 3 | `Add RuboCop step to CI workflow` |

## 3. How (Operation and Maintenance)

### 3-1. Local Development

Run RuboCop locally before pushing:

```bash
# Pure Ruby projects
cd ruby/
rubocop

# Rails projects
cd ruby-on-rails/<project>/
bundle exec rubocop
```

Auto-correct safe violations:

```bash
rubocop -a          # safe auto-corrections only
rubocop -A          # safe + unsafe auto-corrections (review changes carefully)
```

### 3-2. CI Enforcement

RuboCop runs automatically on every push to `master` and on every pull request via GitHub Actions. A failing RuboCop check will block the workflow, ensuring no style violations reach the default branch.

### 3-3. Updating Rules

- `NewCops: enable` is set so newly added cops from RuboCop upgrades are automatically enabled.
- To suppress a specific cop for a project, add an override to its `.rubocop.yml`:

  ```yaml
  Style/SomeCop:
    Enabled: false
  ```

- To suppress inline:

  ```ruby
  # rubocop:disable Style/SomeCop
  some_code
  # rubocop:enable Style/SomeCop
  ```

### 3-4. Keeping Dependencies Up to Date

Periodically update RuboCop and its extensions:

```bash
# Rails projects
bundle update rubocop rubocop-performance rubocop-rails rubocop-rspec
bundle update rubocop rubocop-performance rubocop-rails rubocop-minitest

# Pure Ruby projects
gem update rubocop rubocop-minitest rubocop-performance
```

## 4. Pros & Cons

### 4-1. Pros

| # | Advantage | Description |
|---|-----------|-------------|
| 1 | Consistent code style | Enforces the community Ruby Style Guide across all projects uniformly |
| 2 | Early bug detection | Catches potential issues (e.g. unused variables, shadowed arguments) before runtime |
| 3 | Performance insights | `rubocop-performance` identifies inefficient patterns and suggests faster alternatives |
| 4 | Framework-aware checks | `rubocop-rails` / `rubocop-rspec` / `rubocop-minitest` enforce framework-specific best practices |
| 5 | Automated enforcement | CI integration prevents regressions without relying on manual review |
| 6 | Auto-correction | Many violations can be fixed automatically with `rubocop -a` |
| 7 | Low friction | Runs as a standalone step; does not interfere with test execution |

### 4-2. Cons

| # | Disadvantage | Mitigation |
|---|-------------|------------|
| 1 | Initial noise | Existing code may produce many violations on first run; fix incrementally or use `rubocop --auto-gen-config` to generate a TODO file |
| 2 | Opinionated defaults | Some rules may conflict with project conventions; override in `.rubocop.yml` as needed |
| 3 | CI time increase | Adds a few seconds to each workflow run; negligible compared to test and build steps |
| 4 | Upgrade churn | `NewCops: enable` may introduce new violations on gem updates; review release notes before updating |