### PR TITLE
[ruby] Resolve Errors And Warnings Reported By Rubocop

### DIFF
--- a/ruby/Steepfile
+++ b/ruby/Steepfile
@@ -1,17 +1,19 @@
+# frozen_string_literal: true
+
 D = Steep::Diagnostic
 
 target :app do
-  check "exec"
-  check "src"
-  check "test"
-  signature "sig"
+  check 'exec'
+  check 'src'
+  check 'test'
+  signature 'sig'
 
-  library "csv"
-  library "json"
-  library "fileutils"
-  library "minitest"
-  library "net-http"
-  library "uri"
+  library 'csv'
+  library 'json'
+  library 'fileutils'
+  library 'minitest'
+  library 'net-http'
+  library 'uri'
 
   configure_code_diagnostics(D::Ruby.default)
 end

--- a/ruby/src/queries/accuracy_check_query.rb
+++ b/ruby/src/queries/accuracy_check_query.rb
@@ -7,7 +7,7 @@ require 'json'
 module Queries
   class AccuracyCheckQuery
 
-    INVALID_PATTERNS = /[\\\'\'\|\`\^\"\<\>\)\(\}\{\]\[\;\/\?\:\@\&\=\+\$\,\%\# ]/
+    INVALID_PATTERNS = /[\\\'\|\`\^\"\<\>\)\(\}\{\]\[\;\/\?\:\@\&\=\+\$\,\%\# ]/
 
     # @rbs scheme: String
     # @rbs host: String


### PR DESCRIPTION
Inspecting 14 files
.C.....W......

Offenses:

Steepfile:1:1: C: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
D = Steep::Diagnostic
^
Steepfile:2:1: C: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
D = Steep::Diagnostic
^
Steepfile:4:9: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  check "exec"
        ^^^^^^
Steepfile:5:9: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  check "src"
        ^^^^^
Steepfile:6:9: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  check "test"
        ^^^^^^
Steepfile:7:13: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  signature "sig"
            ^^^^^
Steepfile:9:11: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  library "csv"
          ^^^^^
Steepfile:10:11: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  library "json"
          ^^^^^^
Steepfile:11:11: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  library "fileutils"
          ^^^^^^^^^^^
Steepfile:12:11: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  library "minitest"
          ^^^^^^^^^^
Steepfile:13:11: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  library "net-http"
          ^^^^^^^^^^
Steepfile:14:11: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  library "uri"
          ^^^^^
src/queries/accuracy_check_query.rb:10:30: W: [Corrected] Lint/DuplicateRegexpCharacterClassElement: Duplicate element inside regexp character class
    INVALID_PATTERNS = /[\\\'\'\|\`\^\"\<\>\)\(\}\{\]\[\;\/\?\:\@\&\=\+\$\,\%\# ]/
                             ^^

14 files inspected, 13 offenses detected, 13 offenses corrected