### PR TITLE
[ruby][ruby-on-rails] Add Missing bundle exec Prefix to Commands

### DIFF
--- a/.github/workflows/ruby-on-rails.yml
+++ b/.github/workflows/ruby-on-rails.yml
@@ -99,18 +99,18 @@ jobs:
               ruby-on-rails/rubocop_todo.yml
               ruby-on-rails/**/*.rb
               ruby-on-rails/**/*.rake
-            steep: |
-              .github/actions/setup-ruby-on-rails/action.yml
-              .github/workflows/ruby-on-rails.yml
-              .ruby-version
-              ruby-on-rails/.ruby-version
-              ruby-on-rails/Gemfile
-              ruby-on-rails/Gemfile.lock
-              ruby-on-rails/Rakefile
-              ruby-on-rails/Steepfile
-              ruby-on-rails/**/*.rb
-              ruby-on-rails/**/*.rbs
-              ruby-on-rails/**/*.rake
+            # steep: |
+            #   .github/actions/setup-ruby-on-rails/action.yml
+            #   .github/workflows/ruby-on-rails.yml
+            #   .ruby-version
+            #   ruby-on-rails/.ruby-version
+            #   ruby-on-rails/Gemfile
+            #   ruby-on-rails/Gemfile.lock
+            #   ruby-on-rails/Rakefile
+            #   ruby-on-rails/Steepfile
+            #   ruby-on-rails/**/*.rb
+            #   ruby-on-rails/**/*.rbs
+            #   ruby-on-rails/**/*.rake
   rspec:
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -129,10 +129,10 @@ jobs:
     if: needs.change-detection.outputs.ruby-changes == 'true'
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-ruby
+      - uses: ./.github/actions/setup-ruby-on-rails
       - name: Brakeman
         working-directory: ./ruby
-        run: brakeman --no-pager
+        run: bundle exec brakeman --no-pager
   rubocop:
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -143,7 +143,7 @@ jobs:
       - uses: ./.github/actions/setup-ruby-on-rails
       - name: RuboCop
         working-directory: ./ruby-on-rails
-        run: rubocop
+        run: bundle exec rubocop
   # steep:
   #   timeout-minutes: 10
   #   runs-on: ubuntu-latest
@@ -155,5 +155,5 @@ jobs:
   #     - name: Steep
   #       working-directory: ./ruby-on-rails
   #       run: |
-  #         rbs-inline --output sig/generated/ .
-  #         steep check
+  #         bundle exec rbs-inline --output sig/generated/ .
+  #         bundle exec steep check

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -103,7 +103,7 @@ jobs:
           job-name: Brakeman
       - name: Brakeman
         working-directory: ./ruby
-        run: brakeman --no-pager
+        run: bundle exec brakeman --no-pager
   rubocop:
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -116,7 +116,7 @@ jobs:
           job-name: RuboCop
       - name: RuboCop
         working-directory: ./ruby
-        run: rubocop
+        run: bundle exec rubocop
   # steep:
   #   timeout-minutes: 10
   #   runs-on: ubuntu-latest
@@ -130,5 +130,5 @@ jobs:
   #     - name: Steep
   #       working-directory: ./ruby
   #       run: |
-  #         rbs-inline --output sig/generated/ .
-  #         steep check
+  #         bundle exec rbs-inline --output sig/generated/ .
+  #         bundle exec steep check


### PR DESCRIPTION
## Summary

Brakeman, RuboCop, rbs-inline and Steep are available via Gemfile and Bundler, so they require `bundle exec` prefix to invoke.