### PR TITLE
[ruby] Fix Invalid Paths Filters on GitHub Actions

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -20,5 +20,6 @@ runs:
       working-directory: ./ruby
       run: |
         bundle config set path vendor/bundle
-        bundle install --with=${{ inputs.job-name }}
+        bundle config set with ${{ inputs.job-name }}
+        bundle install
         bundle lock --add-checksums

--- a/.github/workflows/ruby-on-rails.yml
+++ b/.github/workflows/ruby-on-rails.yml
@@ -61,9 +61,9 @@ jobs:
   change-detection:
     runs-on: ubuntu-latest
     outputs:
-      ruby-changes: ${{ steps.ruby.outputs.changes }}
-      rubocop-changes: ${{ steps.rubocop.outputs.changes }}
-      # steep-changes: ${{ steps.steep.outputs.changes }}
+      ruby-changes: ${{ steps.change-detection.outputs.ruby }}
+      rubocop-changes: ${{ steps.change-detection.outputs.rubocop}}
+      # steep-changes: ${{ steps.change-detection.outputs.steep}}
     steps:
       - uses: actions/checkout@v6
       - name: Change Detection

--- a/.github/workflows/ruby-on-rails.yml
+++ b/.github/workflows/ruby-on-rails.yml
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-ruby-on-rails
       - name: Brakeman
-        working-directory: ./ruby
+        working-directory: ./ruby-on-rails
         run: bundle exec brakeman --no-pager
   rubocop:
     timeout-minutes: 10

--- a/.github/workflows/ruby-on-rails.yml
+++ b/.github/workflows/ruby-on-rails.yml
@@ -71,46 +71,46 @@ jobs:
         id: change-detection
         with:
           filters: |
-            ruby: |
-              .github/actions/setup-ruby-on-rails/action.yml
-              .github/workflows/ruby-on-rails.yml
-              .ruby-version
-              ruby-on-rails/.ruby-version
-              ruby-on-rails/Gemfile
-              ruby-on-rails/Gemfile.lock
-              ruby-on-rails/Rakefile
-              ruby-on-rails/**/*.rb
-              ruby-on-rails/**/*.rake
-              ruby-on-rails/**/*.yml
-              ruby-on-rails/**/*.js
-              ruby-on-rails/**/*.css
-              ruby-on-rails/**/*.html.erb
-              ruby-on-rails/**/*.csv
-              ruby-on-rails/**/*.json
-            rubocop: |
-              .github/actions/setup-ruby-on-rails/action.yml
-              .github/workflows/ruby-on-rails.yml
-              .ruby-version
-              ruby-on-rails/.ruby-version
-              ruby-on-rails/Gemfile
-              ruby-on-rails/Gemfile.lock
-              ruby-on-rails/Rakefile
-              ruby-on-rails/rubocop.yml
-              ruby-on-rails/rubocop_todo.yml
-              ruby-on-rails/**/*.rb
-              ruby-on-rails/**/*.rake
-            # steep: |
-            #   .github/actions/setup-ruby-on-rails/action.yml
-            #   .github/workflows/ruby-on-rails.yml
-            #   .ruby-version
-            #   ruby-on-rails/.ruby-version
-            #   ruby-on-rails/Gemfile
-            #   ruby-on-rails/Gemfile.lock
-            #   ruby-on-rails/Rakefile
-            #   ruby-on-rails/Steepfile
-            #   ruby-on-rails/**/*.rb
-            #   ruby-on-rails/**/*.rbs
-            #   ruby-on-rails/**/*.rake
+            ruby:
+              - .github/actions/setup-ruby-on-rails/action.yml
+              - .github/workflows/ruby-on-rails.yml
+              - .ruby-version
+              - ruby-on-rails/.ruby-version
+              - ruby-on-rails/Gemfile
+              - ruby-on-rails/Gemfile.lock
+              - ruby-on-rails/Rakefile
+              - ruby-on-rails/**/*.rb
+              - ruby-on-rails/**/*.rake
+              - ruby-on-rails/**/*.yml
+              - ruby-on-rails/**/*.js
+              - ruby-on-rails/**/*.css
+              - ruby-on-rails/**/*.html.erb
+              - ruby-on-rails/**/*.csv
+              - ruby-on-rails/**/*.json
+            rubocop:
+              - .github/actions/setup-ruby-on-rails/action.yml
+              - .github/workflows/ruby-on-rails.yml
+              - .ruby-version
+              - ruby-on-rails/.ruby-version
+              - ruby-on-rails/Gemfile
+              - ruby-on-rails/Gemfile.lock
+              - ruby-on-rails/Rakefile
+              - ruby-on-rails/rubocop.yml
+              - ruby-on-rails/rubocop_todo.yml
+              - ruby-on-rails/**/*.rb
+              - ruby-on-rails/**/*.rake
+            # steep:
+              # - .github/actions/setup-ruby-on-rails/action.yml
+              # - .github/workflows/ruby-on-rails.yml
+              # - .ruby-version
+              # - ruby-on-rails/.ruby-version
+              # - ruby-on-rails/Gemfile
+              # - ruby-on-rails/Gemfile.lock
+              # - ruby-on-rails/Rakefile
+              # - ruby-on-rails/Steepfile
+              # - ruby-on-rails/**/*.rb
+              # - ruby-on-rails/**/*.rbs
+              # - ruby-on-rails/**/*.rake
   rspec:
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -53,31 +53,31 @@ jobs:
         id: change-detection
         with:
           filters: |
-            ruby: |
-              .github/actions/setup-ruby/action.yml
-              .github/workflows/ruby.yml
-              .ruby-version
-              ruby/**/*.rb
-              ruby/Gemfile
-              ruby/Gemfile.lock
-            rubocop: |
-              .github/actions/setup-ruby/action.yml
-              .github/workflows/ruby.yml
-              .ruby-version
-              ruby/**/*.rb
-              ruby/rubocop.yml
-              ruby/rubocop_todo.yml
-              ruby/Gemfile
-              ruby/Gemfile.lock
-            # steep: |
-            #   .github/actions/setup-ruby/action.yml
-            #   .github/workflows/ruby.yml
-            #   .ruby-version
-            #   ruby/**/*.rb
-            #   ruby/**/*.rbs
-            #   ruby/Gemfile
-            #   ruby/Gemfile.lock
-            #   ruby/Steepfile
+            ruby:
+              - .github/actions/setup-ruby/action.yml
+              - .github/workflows/ruby.yml
+              - .ruby-version
+              - ruby/**/*.rb
+              - ruby/Gemfile
+              - ruby/Gemfile.lock
+            rubocop:
+              - .github/actions/setup-ruby/action.yml
+              - .github/workflows/ruby.yml
+              - .ruby-version
+              - ruby/**/*.rb
+              - ruby/rubocop.yml
+              - ruby/rubocop_todo.yml
+              - ruby/Gemfile
+              - ruby/Gemfile.lock
+            # steep:
+              # - .github/actions/setup-ruby/action.yml
+              # - .github/workflows/ruby.yml
+              # - .ruby-version
+              # - ruby/**/*.rb
+              # - ruby/**/*.rbs
+              # - ruby/Gemfile
+              # - ruby/Gemfile.lock
+              # - ruby/Steepfile
   minitest:
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -91,19 +91,6 @@ jobs:
       - name: Minitest
         working-directory: ./ruby
         run: rake
-  brakeman:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    needs: change-detection
-    if: needs.change-detection.outputs.ruby-changes == 'true'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-ruby
-        with:
-          job-name: Brakeman
-      - name: Brakeman
-        working-directory: ./ruby
-        run: bundle exec brakeman --no-pager
   rubocop:
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -43,9 +43,9 @@ jobs:
   change-detection:
     runs-on: ubuntu-latest
     outputs:
-      ruby-changes: ${{ steps.ruby.outputs.changes }}
-      rubocop-changes: ${{ steps.rubocop.outputs.changes }}
-      # steep-changes: ${{ steps.steep.outputs.changes }}
+      ruby-changes: ${{ steps.change-detection.outputs.ruby }}
+      rubocop-changes: ${{ steps.change-detection.outputs.rubocop }}
+      # steep-changes: ${{ steps.change-detection.outputs.steep }}
     steps:
       - uses: actions/checkout@v6
       - name: Change Detection

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,9 +1,5 @@
 source 'https://rubygems.org'
 
-group :brakeman do
-  gem 'brakeman', '~> 8.0.4', require: false
-end
-
 group :rubocop do
   gem 'rubocop', '~> 1.86.1', require: false
   gem 'rubocop-minitest', '~> 0.39.1', require: false

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -2,8 +2,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    brakeman (8.0.4)
-      racc
     concurrent-ruby (1.3.6)
     csv (3.3.5)
     ffi (1.17.4)
@@ -107,7 +105,6 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  brakeman (~> 8.0.4)
   rbs-inline (~> 0.13.0)
   rubocop (~> 1.86.1)
   rubocop-minitest (~> 0.39.1)
@@ -116,7 +113,6 @@ DEPENDENCIES
 
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf


### PR DESCRIPTION
## 1. Summary

Fixed invalid attrribute access on GitHub Actions workflows configuration files.
Even if the step detects changes in the target files, no jobs run, which should be fixed.

<img width="347" height="183" alt="Screenshot 2026-04-22 144146" src="https://github.com/user-attachments/assets/9252ac00-2ca8-4939-a452-e5c99c9c4bee" />

## 2. Changes

- [Fix invalid paths filters on GitHub Actions](https://github.com/hayat01sh1da/botpress-accuracy-checkers/pull/110/commits/6bec9b1a224ea12352bca5e9d0420c11d2e6e6e9)
- [Fix list syntax for paths filters on GitHub Actions](https://github.com/hayat01sh1da/botpress-accuracy-checkers/pull/110/commits/788a8f2544286ec4d71470383c318eacf20f8582)
- [Replace remove flag with explicit declaration for paths filters on GitHub Actions](https://github.com/hayat01sh1da/botpress-accuracy-checkers/pull/110/commits/166910de1ae13d59f921fa3a2c0af855b36f43bd)