### PR TITLE
[ruby] Abort Path Assignment for `bundle install` on GitHub Actions

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash
       working-directory: ./ruby
       run: |
-        bundle config set --local path vendor/bundle
+        rm -rf .bundle/**
         bundle config set --local with ${{ inputs.job-name }}
         bundle install
         bundle lock --add-checksums

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -15,7 +15,7 @@ runs:
       with:
         bundler-cache: true
     - name: Bundle Install with Caching
-      if: ${{ inputs.job-name != 'Minitest' }}
+      if: ${{ inputs.job-name != 'minitest' }}
       shell: bash
       working-directory: ./ruby
       run: |

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash
       working-directory: ./ruby
       run: |
-        bundle config set path vendor/bundle
-        bundle config set with ${{ inputs.job-name }}
+        bundle config set --local path vendor/bundle
+        bundle config set --local with ${{ inputs.job-name }}
         bundle install
         bundle lock --add-checksums

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-ruby
         with:
-          job-name: Minitest
+          job-name: minitest
       - name: Minitest
         working-directory: ./ruby
         run: rake
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-ruby
         with:
-          job-name: RuboCop
+          job-name: rubocop
       - name: RuboCop
         working-directory: ./ruby
         run: bundle exec rubocop
@@ -113,7 +113,7 @@ jobs:
   #     - uses: actions/checkout@v6
   #     - uses: ./.github/actions/setup-ruby
   #       with:
-  #         job-name: Steep
+  #         job-name: steep
   #     - name: Steep
   #       working-directory: ./ruby
   #       run: |

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -5,7 +5,7 @@
 ## 2. Install Gems via Gemfile and Bundler
 
 ```command
-$ bundle config set path vendor/bundle
+$ bundle config set --local path vendor/bundle
 $ bundle install
 $ bundle lock --add-checksums
 ```


### PR DESCRIPTION
## 1. Summary

`bundle config set [--local/global] path vendor/bundle` prevents bundler from finding installed Gem, particularly Steep.
It should be aborted.

## 2. Commits

- [Downcase case-sensitive strings on GitHub Actions](https://github.com/hayat01sh1da/botpress-accuracy-checkers/pull/111/commits/eaf4af5a1001b84a2ba2c5cf9dbac187718d0266)
- [Set bundler configuration only in the pure Ruby projects](https://github.com/hayat01sh1da/botpress-accuracy-checkers/pull/111/commits/f7d60f783232c790dbf27ab50bd9a18a137b2178)
- [Abort path assignment for bundle install on GitHub Actions](https://github.com/hayat01sh1da/botpress-accuracy-checkers/pull/111/commits/8e9a3bbff84ba5290fa7bb22ef448177854e3d51)