### PR TITLE
[ruby] Migrate from Local to Global Bundle Installation

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -20,6 +20,5 @@ runs:
       working-directory: ./ruby
       run: |
         rm -rf .bundle/**
-        bundle config set --local with ${{ inputs.job-name }}
         bundle install
         bundle lock --add-checksums

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ ruby-on-rails/tmp/
 
 # Ruby
 
-ruby/vendor/bundle/**
 ruby/test/tmp
 
 # Python

--- a/ruby-on-rails/.rubocop.yml
+++ b/ruby-on-rails/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 # Reference: https://github.com/rubocop/ruby-style-guide
 
-require:
+plugins:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec

--- a/ruby/.bundle/config
+++ b/ruby/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_PATH: "vendor/bundle"

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 # Reference: https://github.com/rubocop/ruby-style-guide
 
-require:
+plugins:
   - rubocop-minitest
   - rubocop-performance
 

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'rbs-inline', '~> 0.13.0', require: false
 gem 'rubocop', '~> 1.86.1', require: false
 gem 'rubocop-minitest', '~> 0.39.1', require: false
 gem 'rubocop-performance', '~> 1.26.1', require: false
-gem 'rbs-inline', '~> 0.13.0', require: false
 gem 'steep', '~> 2.0.0', require: false

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,12 +1,7 @@
 source 'https://rubygems.org'
 
-group :rubocop do
-  gem 'rubocop', '~> 1.86.1', require: false
-  gem 'rubocop-minitest', '~> 0.39.1', require: false
-  gem 'rubocop-performance', '~> 1.26.1', require: false
-end
-
-group :steep do
-  gem 'rbs-inline', '~> 0.13.0', require: false
-  gem 'steep', '~> 2.0.0', require: false
-end
+gem 'rubocop', '~> 1.86.1', require: false
+gem 'rubocop-minitest', '~> 0.39.1', require: false
+gem 'rubocop-performance', '~> 1.26.1', require: false
+gem 'rbs-inline', '~> 0.13.0', require: false
+gem 'steep', '~> 2.0.0', require: false

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -5,7 +5,6 @@
 ## 2. Install Gems via Gemfile and Bundler
 
 ```command
-$ bundle config set --local path vendor/bundle
 $ bundle install
 $ bundle lock --add-checksums
 ```


### PR DESCRIPTION
## Summary

Local Gem installation often disables Bundler to find commands, particularly a Gem is installed both globally and locally.
Only global Gem installation makes fewer confusions, so `bundle config set --local path vendor/bundle` should be aborted.

Besides, grouping on Gemfile makes no effects on GitHub Actions efficiency because of bundler-cache, so it also should be discarded.