### PR TITLE
[REVERT][ruby] Stop Managing Signature Files

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -117,5 +117,4 @@ jobs:
       - name: Steep
         working-directory: ./ruby
         run: |
-          bundle exec rbs-inline --output sig/generated/ .
           bundle exec steep check

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ ruby-on-rails/log/
 ruby-on-rails/tmp/
 
 # Ruby
-ruby/sig/
+
 ruby/test/tmp
 
 # Python

--- a/ruby/sig/generated/exec/accuracy_check_exec.rbs
+++ b/ruby/sig/generated/exec/accuracy_check_exec.rbs
@@ -1,0 +1,2 @@
+# Generated from exec/accuracy_check_exec.rb with RBS::Inline
+

--- a/ruby/sig/generated/exec/training_data_exec.rbs
+++ b/ruby/sig/generated/exec/training_data_exec.rbs
@@ -1,0 +1,2 @@
+# Generated from exec/training_data_exec.rb with RBS::Inline
+

--- a/ruby/sig/generated/src/accuracy_check.rbs
+++ b/ruby/sig/generated/src/accuracy_check.rbs
@@ -1,0 +1,38 @@
+# Generated from src/accuracy_check.rb with RBS::Inline
+
+class AccuracyCheck
+  # @rbs scheme: String
+  # @rbs host: String
+  # @rbs bot_id: String
+  # @rbs user_id: String
+  # @rbs test_data: String
+  # @rbs return: void
+  def initialize: (String scheme, String host, String bot_id, String user_id, String test_data) -> void
+
+  # @rbs dirname: String
+  # @rbs return: void
+  def export_chart: (String dirname) -> void
+
+  private
+
+  attr_reader scheme: untyped
+
+  attr_reader host: untyped
+
+  attr_reader bot_id: untyped
+
+  attr_reader user_id: untyped
+
+  attr_reader test_data: untyped
+
+  # @rbs return: Queries::AccuracyCheckQuery
+  def accuracy_check_query: () -> Queries::AccuracyCheckQuery
+
+  # @rbs res_bodies: Array[Hash[String, untyped]]
+  # @rbs return: Lib::ChartDrawer
+  def chart_drawer: (Array[Hash[String, untyped]] res_bodies) -> Lib::ChartDrawer
+
+  # @rbs dirname: String
+  # @rbs return: String
+  def filename: (String dirname) -> String
+end

--- a/ruby/sig/generated/src/lib/chart_drawer.rbs
+++ b/ruby/sig/generated/src/lib/chart_drawer.rbs
@@ -1,0 +1,28 @@
+# Generated from src/lib/chart_drawer.rb with RBS::Inline
+
+module Lib
+  class ChartDrawer
+    # @rbs test_data: String
+    # @rbs res_bodies: Array[Hash[String, untyped]]
+    # @rbs return: void
+    def initialize: (String test_data, Array[Hash[String, untyped]] res_bodies) -> void
+
+    # @rbs return: String
+    def csv: () -> String
+
+    private
+
+    attr_reader test_data: untyped
+
+    attr_reader res_bodies: untyped
+
+    # @rbs return: Array[String]
+    def headers: () -> Array[String]
+
+    # @rbs return: Array[Array[Hash[String, (String | Float)]]]
+    def score_tables: () -> Array[Array[Hash[String, String | Float]]]
+
+    # @rbs return: Array[Array[String]]
+    def rows: () -> Array[Array[String]]
+  end
+end

--- a/ruby/sig/generated/src/lib/format.rbs
+++ b/ruby/sig/generated/src/lib/format.rbs
@@ -1,0 +1,13 @@
+# Generated from src/lib/format.rb with RBS::Inline
+
+module Lib
+  module Format
+    # @rbs return: Hash[Symbol, untyped]
+    def template: (?untyped array) -> Hash[Symbol, untyped]
+
+    # @rbs training_data: String
+    # @rbs array: Array[untyped]
+    # @rbs return: String
+    def to_json: (String training_data, ?Array[untyped] array) -> String
+  end
+end

--- a/ruby/sig/generated/src/queries/accuracy_check_query.rbs
+++ b/ruby/sig/generated/src/queries/accuracy_check_query.rbs
@@ -1,0 +1,41 @@
+# Generated from src/queries/accuracy_check_query.rb with RBS::Inline
+
+module Queries
+  class AccuracyCheckQuery
+    INVALID_PATTERNS: ::Regexp
+
+    # @rbs scheme: String
+    # @rbs host: String
+    # @rbs bot_id: String
+    # @rbs user_id: String
+    # @rbs test_data: String
+    # @rbs return: void
+    def initialize: (String scheme, String host, String bot_id, String user_id, String test_data) -> void
+
+    # @rbs return: Array[Hash[String, untyped]]
+    def res_bodies: () -> Array[Hash[String, untyped]]
+
+    private
+
+    attr_reader scheme: untyped
+
+    attr_reader host: untyped
+
+    attr_reader bot_id: untyped
+
+    attr_reader user_id: untyped
+
+    attr_reader test_data: untyped
+
+    attr_reader req: untyped
+
+    # @rbs return: URI::Generic
+    def uri: () -> URI::Generic
+
+    # @rbs return: void
+    def authorized: () -> void
+
+    # @rbs return: Array[Net::HTTPResponse]
+    def request: () -> Array[Net::HTTPResponse]
+  end
+end

--- a/ruby/sig/generated/src/training_data.rbs
+++ b/ruby/sig/generated/src/training_data.rbs
@@ -1,0 +1,21 @@
+# Generated from src/training_data.rb with RBS::Inline
+
+class TrainingData
+  include ::Lib::Format
+
+  # @rbs training_data: String
+  # @rbs return: void
+  def initialize: (String training_data) -> void
+
+  # @rbs dirname: String
+  # @rbs return: void
+  def export: (String dirname) -> void
+
+  private
+
+  attr_reader training_data: untyped
+
+  # @rbs dirname: String
+  # @rbs return: String
+  def filename: (String dirname) -> String
+end

--- a/ruby/sig/generated/test/accuracy_check_test.rbs
+++ b/ruby/sig/generated/test/accuracy_check_test.rbs
@@ -1,0 +1,2 @@
+# Generated from test/accuracy_check_test.rb with RBS::Inline
+

--- a/ruby/sig/generated/test/application_test.rbs
+++ b/ruby/sig/generated/test/application_test.rbs
@@ -1,0 +1,11 @@
+# Generated from test/application_test.rb with RBS::Inline
+
+class ApplicationTest < Minitest::Test
+  def setup: () -> untyped
+
+  def teardown: () -> untyped
+
+  private
+
+  attr_reader dirname: untyped
+end

--- a/ruby/sig/generated/test/lib/chart_drawer_test.rbs
+++ b/ruby/sig/generated/test/lib/chart_drawer_test.rbs
@@ -1,0 +1,13 @@
+# Generated from test/lib/chart_drawer_test.rb with RBS::Inline
+
+class ChartDrawerTest < Minitest::Test
+  def setup: () -> untyped
+
+  def test_csv: () -> untyped
+
+  private
+
+  attr_reader csv_path: untyped
+
+  attr_reader chart_drawer: untyped
+end

--- a/ruby/sig/generated/test/queries/accuracy_check_query_test.rbs
+++ b/ruby/sig/generated/test/queries/accuracy_check_query_test.rbs
@@ -1,0 +1,2 @@
+# Generated from test/queries/accuracy_check_query_test.rb with RBS::Inline
+

--- a/ruby/sig/generated/test/training_data_test.rbs
+++ b/ruby/sig/generated/test/training_data_test.rbs
@@ -1,0 +1,13 @@
+# Generated from test/training_data_test.rb with RBS::Inline
+
+class TrainingDataTest < ApplicationTest
+  def setup: () -> untyped
+
+  def teardown: () -> untyped
+
+  def test_export: () -> untyped
+
+  private
+
+  attr_reader training_data: untyped
+end


### PR DESCRIPTION
## 1. Target PR to Revert

- https://github.com/hayat01sh1da/botpress-accuracy-checkers/pull/113

## 2. Context

Acccording to the article shown below, signrature files should be hosted and ought not to be generated in GitHub Actions workflow because they should be static on a repository.
That is why, `bundle exec rbs-inline --output sig/generated/ .` has been aborted since it generates new signature files and can make differences.

## 3. Reference

- [Rails アプリケーション型付けハンドブック(rbs/steep) > Chapter 04 自前で定義したメソッドの型シグネチャの導入 > 4.4. rbs-inline での出力](https://zenn.dev/sanfrecce_osaka/books/steep-rails-typing-handbook/viewer/introduce-type-signature-for-handwritten-method#4.4.-rbs-inline-での出力)
