### PR TITLE
[ruby][ruby-on-rails] Add Hidden File Marker to RuboCop Configuration Files on Github Actions Workflow

### DIFF
--- a/.github/workflows/ruby-on-rails.yml
+++ b/.github/workflows/ruby-on-rails.yml
@@ -19,8 +19,8 @@ on:
       - ruby-on-rails/Gemfile
       - ruby-on-rails/Gemfile.lock
       - ruby-on-rails/Rakefile
-      - ruby-on-rails/rubocop.yml
-      - ruby-on-rails/rubocop_todo.yml
+      - ruby-on-rails/.rubocop.yml
+      - ruby-on-rails/.rubocop_todo.yml
       # - ruby-on-rails/Steepfile
       - ruby-on-rails/**/*.rb
       # - ruby-on-rails/**/*.rbs
@@ -40,8 +40,8 @@ on:
       - ruby-on-rails/Gemfile
       - ruby-on-rails/Gemfile.lock
       - ruby-on-rails/Rakefile
-      - ruby-on-rails/rubocop.yml
-      - ruby-on-rails/rubocop_todo.yml
+      - ruby-on-rails/.rubocop.yml
+      - ruby-on-rails/.rubocop_todo.yml
       # - ruby-on-rails/Steepfile
       - ruby-on-rails/**/*.rb
       # - ruby-on-rails/**/*.rbs
@@ -95,8 +95,8 @@ jobs:
               - ruby-on-rails/Gemfile
               - ruby-on-rails/Gemfile.lock
               - ruby-on-rails/Rakefile
-              - ruby-on-rails/rubocop.yml
-              - ruby-on-rails/rubocop_todo.yml
+              - ruby-on-rails/.rubocop.yml
+              - ruby-on-rails/.rubocop_todo.yml
               - ruby-on-rails/**/*.rb
               - ruby-on-rails/**/*.rake
             # steep:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,8 +19,8 @@ on:
       - ruby/**/*.rbs
       - ruby/Gemfile
       - ruby/Gemfile.lock
-      - ruby/rubocop.yml
-      - ruby/rubocop_todo.yml
+      - ruby/.rubocop.yml
+      - ruby/.rubocop_todo.yml
       - ruby/Steepfile
   pull_request:
     paths:
@@ -31,8 +31,8 @@ on:
       - ruby/**/*.rbs
       - ruby/Gemfile
       - ruby/Gemfile.lock
-      - ruby/rubocop.yml
-      - ruby/rubocop_todo.yml
+      - ruby/.rubocop.yml
+      - ruby/.rubocop_todo.yml
       - ruby/Steepfile
 
 permissions:
@@ -65,8 +65,8 @@ jobs:
               - .github/workflows/ruby.yml
               - .ruby-version
               - ruby/**/*.rb
-              - ruby/rubocop.yml
-              - ruby/rubocop_todo.yml
+              - ruby/.rubocop.yml
+              - ruby/.rubocop_todo.yml
               - ruby/Gemfile
               - ruby/Gemfile.lock
             steep:


### PR DESCRIPTION
## Summary

On Github Actions workflow cofigutration file, RuboCop-related files are assigned as `ruby/rubocop*.yml` to the target paths.
However, they are missing the hidden file marker `.`, which fails to trigger RuboCop workflow.
It should be fixed.