### PR TITLE
[ruby-on-rails] Bump Docker to 29.4.1

### DIFF
--- a/ruby-on-rails/README.md
+++ b/ruby-on-rails/README.md
@@ -2,7 +2,7 @@
 
 - Rails 8.1.2
 - Ruby 4.0.3
-- Docker 29.4.0
+- Docker 29.4.1
 
 ## 2. Setup Docker
 


### PR DESCRIPTION
## 1. Key Differences & Updates

### 1-1. Security Patches

Version 29.4.1 includes fixes for several high-severity vulnerabilities (CVEs) identified in the previous version, including:

- [CVE-2026-31789](https://nvd.nist.gov/vuln/detail/CVE-2026-31789) (Critical, 9.8 score)
- [CVE-2026-33186](https://nvd.nist.gov/vuln/detail/CVE-2026-33186) (Critical, 9.1 score)
- [CVE-2026-34040](https://nvd.nist.gov/vuln/detail/CVE-2026-34040)

### 1-2. Dependency Updates

The 29.4.1 release updated internal components, such as bumping https://github.com/docker/cli to its corresponding version to ensure compatibility across the toolchain.

### 1-3. Distribution

Both versions are available across standard repositories for [Debian](https://docs.docker.com/engine/install/debian/) and [Ubuntu](https://docs.docker.com/engine/install/ubuntu/), allowing users to specifically select 29.4.1 for the latest security enhancements.

## 2. Release Context

Released around **April 20–21, 2026**, version 29.4.1 serves as the current stable point for the v29 series. It maintains the foundational changes introduced in the major v29 update, such as the continued evolution of the [containerd image store](https://www.docker.com/blog/docker-engine-version-29/).

## 3. Reference

- [National Vulnerability Database](https://nvd.nist.gov/)