### PR TITLE
[ruby-on-rails] Update Gem Dependencies

### DIFF
--- a/ruby-on-rails/Gemfile
+++ b/ruby-on-rails/Gemfile
@@ -6,18 +6,18 @@ ruby file: '.ruby-version'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 8.1.3'
 # Use Puma as the app server
-gem 'puma', '~> 8.0.0'
+gem 'puma', '~> 8.0.1'
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails', '~> 3.5.2'
 
 gem 'dotenv-rails', '~> 3.2.0'
 
-gem 'nokogiri', '~> 1.19.2'
+gem 'nokogiri', '~> 1.19.3'
 
 gem 'rexml', '~> 3.4.4'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '~> 1.23.0', require: false
+gem 'bootsnap', '~> 1.24.0', require: false
 
 # CSV
 gem 'csv', '~> 3.3.5'

--- a/ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/Gemfile.lock
@@ -77,9 +77,9 @@ GEM
       uri (>= 0.13.1)
     ast (2.4.3)
     base64 (0.3.0)
-    bigdecimal (4.1.1)
+    bigdecimal (4.1.2)
     bindex (0.8.1)
-    bootsnap (1.23.0)
+    bootsnap (1.24.0)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc
@@ -107,12 +107,12 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    irb (1.17.0)
+    irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.19.3)
+    json (2.19.4)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -127,11 +127,11 @@ GEM
       net-smtp
     marcel (1.1.0)
     mini_mime (1.1.5)
-    minitest (6.0.3)
+    minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -141,10 +141,10 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.2-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.3)
-    parallel (2.0.1)
+    parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
@@ -155,7 +155,7 @@ GEM
     psych (5.3.1)
       date
       stringio
-    puma (8.0.0)
+    puma (8.0.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -199,7 +199,7 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.3.1)
+    rake (13.4.2)
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -287,15 +287,15 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  bootsnap (~> 1.23.0)
+  bootsnap (~> 1.24.0)
   brakeman (~> 8.0.4)
   csv (~> 3.3.5)
   debug
   dotenv-rails (~> 3.2.0)
   ffi (~> 1.17.4)
-  nokogiri (~> 1.19.2)
+  nokogiri (~> 1.19.3)
   ostruct (~> 0.6.3)
-  puma (~> 8.0.0)
+  puma (~> 8.0.1)
   rack-mini-profiler (~> 4.0.1)
   rails (~> 8.1.3)
   rexml (~> 3.4.4)
@@ -323,9 +323,9 @@ CHECKSUMS
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
-  bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
-  bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
+  bootsnap (1.24.0) sha256=34e6dea61ff4895101aa9c10894ce30186bec73fe2279e0eb52040d8d4cec297
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
@@ -345,8 +345,8 @@ CHECKSUMS
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
-  irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
-  json (2.19.3) sha256=289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646
+  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
+  json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
@@ -354,22 +354,22 @@ CHECKSUMS
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  minitest (6.0.3) sha256=88ac8a1de36c00692420e7cb3cc11a0773bbcb126aee1c249f320160a7d11411
+  minitest (6.0.5) sha256=f007d7246bf4feea549502842cd7c6aba8851cdc9c90ba06de9c476c0d01155c
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
-  net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
+  net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
-  nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
+  nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
-  parallel (2.0.1) sha256=337782d3e39f4121e67563bf91dd8ece67f48923d90698614773a0ec9a5b2c7d
+  parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
-  puma (8.0.0) sha256=1681050b8b60fab1d3033255ab58b6aec64cd063e43fc6f8204bcb8bf9364b88
+  puma (8.0.1) sha256=7b94e50c07655718c1fb8ae41a11fc06c7d61293208b3aa608ff71a46d3ad37c
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
   rack-mini-profiler (4.0.1) sha256=485810c23211f908196c896ea10cad72ed68780ee2998bec1f1dfd7558263d78
@@ -381,7 +381,7 @@ CHECKSUMS
   rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
-  rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
@@ -415,7 +415,7 @@ CHECKSUMS
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
 
 RUBY VERSION
-  ruby 4.0.2
+  ruby 4.0.3
 
 BUNDLED WITH
   4.0.10


### PR DESCRIPTION
## 1. Summary

This summary outlines the differences between the older and newer versions of each Gem as updated in [PR #118](https://github.com/hayat01sh1da/botpress-accuracy-checkers/pull/118).

## 2. Updated Gems

| Gem Name    | Old Version   | New Version   | Notes |
|------------|--------------|--------------|-------|
| puma       | ~> 8.0.0     | ~> 8.0.1     | Patch update, bug fixes and minor improvements. |
| nokogiri   | ~> 1.19.2    | ~> 1.19.3    | Patch update, likely includes bug fixes and security updates. |
| bootsnap   | ~> 1.23.0    | ~> 1.24.0    | Patch update, performance and compatibility improvements. |
| bigdecimal | 4.1.1        | 4.1.2        | Patch update. |
| irb        | 1.17.0       | 1.18.0       | Patch update. |
| json       | 2.19.3       | 2.19.4       | Patch update. |
| minitest   | 6.0.3        | 6.0.5        | Patch update. |
| net-imap   | 0.6.3        | 0.6.4        | Patch update. |
| parallel   | 2.0.1        | 2.1.0        | Minor update. |
| rake       | 13.3.1       | 13.4.2       | Patch update. |
| nokogiri (platform) | 1.19.2-x86_64-linux-gnu | 1.19.3-x86_64-linux-gnu | Platform-specific update. |
| puma (platform)     | 8.0.0 | 8.0.1 | Platform-specific update. |
| ruby       | 4.0.2        | 4.0.3        | Ruby version update. |

## 3. Notable Points
- All updates are patch or minor version bumps, indicating bug fixes, security patches, or minor improvements.
- No major version upgrades or breaking changes detected.
- Platform-specific gems (nokogiri, puma) also updated.

## 4. Release Notes

- [bigdecimal](https://github.com/ruby/bigdecimal)
  - [4.1.2](https://github.com/ruby/bigdecimal/releases/tag/v4.1.2)
  - [Diffs](https://github.com/ruby/bigdecimal/compare/v4.1.1...v4.1.2)
- [irb](https://github.com/ruby/irb)
  - [v1.18.0](https://github.com/ruby/irb/releases/tag/v1.18.0)
  - [Diffs](https://github.com/ruby/irb/compare/v1.17.0...v1.18.0)
- [json](https://github.com/ruby/json)
  - [v2.19.4](https://github.com/ruby/json/releases/tag/v2.19.4)
  - [Diffs](https://github.com/ruby/json/compare/v2.19.3...v2.19.4)
- [minitest](https://github.com/minitest/minitest)
  - [6.0.5 / 2026-04-20](https://github.com/minitest/minitest/blob/master/History.rdoc#605--2026-04-20)
  - [Diffs](https://github.com/minitest/minitest/compare/v6.0.3...v6.0.5)
- [net-imap](https://github.com/ruby/net-imap)
  - [v0.6.4](https://github.com/ruby/net-imap/releases/tag/v0.6.4)
  - [Diffs](https://github.com/ruby/net-imap/compare/v0.6.3...v0.6.4)
- [nokogiri](https://github.com/sparklemotion/nokogiri)
  - [v1.19.3](https://github.com/sparklemotion/nokogiri/releases/tag/v1.19.3)
  - [Diffs](https://github.com/sparklemotion/nokogiri/compare/v1.19.2...v1.19.3)
- [parallel](https://github.com/grosser/parallel)  
  - [2.1.0](https://github.com/grosser/parallel/blob/v2.1.0/CHANGELOG.md#210)
  - [Diffs](https://github.com/grosser/parallel/compare/v2.0.1...v2.1.0)
- [puma](https://github.com/puma/puma)
  - [v8.0.1](https://github.com/puma/puma/releases/tag/v8.0.1)
  - [Diffs](https://github.com/puma/puma/compare/v8.0.0...v8.0.1)
- [rake](https://github.com/ruby/rake)
  - [v13.4.2](https://github.com/ruby/rake/releases/tag/v13.4.2)
  - [Diffs](https://github.com/ruby/rake/compare/v13.3.1...v13.4.2)
- [bootsnap](https://github.com/rails/bootsnap)
  - [v1.24.0](https://github.com/rails/bootsnap/blob/main/CHANGELOG.md#1240)
  - [Diffs](https://github.com/rails/bootsnap/compare/v1.23.0...v1.24.0)