### PR TITLE
[ruby] Amend README

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -12,7 +12,6 @@ $ bundle lock --add-checksums
 ## 3. Bulk Execution of Unit Tests
 
 ```command
-$ cd ./ruby
 $ rake
 Run options: --seed 32524
 


### PR DESCRIPTION
## Summary

The path to execute the script is self-evident, so omit the description of `cd ruby/`.