### PR TITLE
[python] Rename Label to pytest on Github Actions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python
-      - name: UnitTest
+      - name: pytest
         working-directory: ./python
         run: pytest
   mypy:


### PR DESCRIPTION
## Summary

On GitHub Actions workflow configuration, the job executing `pytest` is named `UnitTest` as it used to be.  
It is confusing a bit so should be amended.