### PR TITLE
[python] Execute Lint Fixes

### DIFF
--- a/python/exec/exec_accuracy_check.py
+++ b/python/exec/exec_accuracy_check.py
@@ -1,3 +1,4 @@
+from accuracy_check import AccuracyCheck
 import os
 import sys
 import shutil
@@ -5,20 +6,19 @@ import glob
 sys.path.append('./src')
 sys.path.append('./src/lib')
 sys.path.append('./src/queries')
-from accuracy_check import AccuracyCheck
 
-scheme    = 'https'
-host      = 'oasist-botpress-server.herokuapp.com'
-bot_id    = 'sample-bot'
-user_id   = 'oasist'
-dirname   = os.path.join('..', 'csv')
+scheme = 'https'
+host = 'oasist-botpress-server.herokuapp.com'
+bot_id = 'sample-bot'
+user_id = 'oasist'
+dirname = os.path.join('..', 'csv')
 test_data = os.path.join(dirname, 'test_data.csv')
 
 accuracy_check = AccuracyCheck(scheme, host, bot_id, user_id, test_data)
 accuracy_check.export_chart(dirname)
 print(f'--- Successfully exported accuracy score chart under {dirname}/ ---')
 
-pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
+pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True)
 for pycache in pycaches:
     if os.path.exists(pycache):
         shutil.rmtree(pycache)

--- a/python/exec/exec_training_data.py
+++ b/python/exec/exec_training_data.py
@@ -1,19 +1,19 @@
+from training_data import TrainingData
 import os
 import sys
 import shutil
 import glob
 sys.path.append('./src')
 sys.path.append('./src/lib')
-from training_data import TrainingData
 
 csv_training_data = os.path.join('..', 'csv', 'training_data.csv')
-dirname           = os.path.join('..', 'json')
+dirname = os.path.join('..', 'json')
 
 training_data = TrainingData(csv_training_data)
 training_data.export(dirname)
 print(f'--- Successfully exported JSON training data under {dirname}/ ---')
 
-pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
+pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True)
 for pycache in pycaches:
     if os.path.exists(pycache):
         shutil.rmtree(pycache)

--- a/python/requirements.lock
+++ b/python/requirements.lock
@@ -1,8 +1,11 @@
+ast_serialize==0.3.0
+autoflake8==0.4.1
+autopep8==2.3.2
 flake8==7.3.0
 iniconfig==2.3.0
-librt==0.9.0
+librt==0.10.0
 mccabe==0.7.0
-mypy==1.20.2
+mypy==2.0.0
 mypy_extensions==1.1.0
 packaging==26.2
 pathspec==1.1.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,5 @@
+autoflake8==0.4.1
+autopep8==2.3.2
 flake8==7.3.0
-mypy==1.20.2
+mypy==2.0.0
 pytest==9.0.3

--- a/python/src/accuracy_check.py
+++ b/python/src/accuracy_check.py
@@ -1,21 +1,29 @@
+from chart_drawer import ChartDrawer
+from accuracy_check_query import AccuracyCheckQuery
 import os
 import datetime
 import sys
 sys.path.append('./src/lib')
 sys.path.append('./src/queries')
-from accuracy_check_query import AccuracyCheckQuery
-from chart_drawer import ChartDrawer
+
 
 class AccuracyCheck:
-    def __init__(self, scheme: str, host: str, bot_id: str, user_id: str, test_data: str) -> None:
-        self.scheme               = scheme
-        self.host                 = host
-        self.bot_id               = bot_id
-        self.user_id              = user_id
-        self.test_data            = test_data
-        self.accuracy_check_query = AccuracyCheckQuery(self.scheme, self.host, self.bot_id, self.user_id, self.test_data)
-        self.res_bodies           = self.accuracy_check_query.res_bodies()
-        self.chart_drawer         = ChartDrawer(self.test_data, self.res_bodies)
+    def __init__(
+            self,
+            scheme: str,
+            host: str,
+            bot_id: str,
+            user_id: str,
+            test_data: str) -> None:
+        self.scheme = scheme
+        self.host = host
+        self.bot_id = bot_id
+        self.user_id = user_id
+        self.test_data = test_data
+        self.accuracy_check_query = AccuracyCheckQuery(
+            self.scheme, self.host, self.bot_id, self.user_id, self.test_data)
+        self.res_bodies = self.accuracy_check_query.res_bodies()
+        self.chart_drawer = ChartDrawer(self.test_data, self.res_bodies)
 
     def export_chart(self, dirname: str) -> None:
         with open(self.__filename__(dirname), 'w') as f:
@@ -24,4 +32,6 @@ class AccuracyCheck:
     # private
 
     def __filename__(self, dirname: str) -> str:
-        return os.path.join(dirname, f'accuracy_score_chart_{datetime.datetime.now():%Y%m%d%H%M%S}.csv')
+        return os.path.join(
+            dirname, f'accuracy_score_chart_{
+                datetime.datetime.now():%Y%m%d%H%M%S}.csv')

--- a/python/src/lib/chart_drawer.py
+++ b/python/src/lib/chart_drawer.py
@@ -1,16 +1,18 @@
 import csv
-import json
 from typing import Any, TextIO
 from list_handler import __csv_to_dicts__
 
+
 class ChartDrawer:
-    def __init__(self, test_data: str, res_bodies: list[dict[str, Any]]) -> None:
-        self.test_data  = __csv_to_dicts__(test_data)
+    def __init__(self, test_data: str,
+                 res_bodies: list[dict[str, Any]]) -> None:
+        self.test_data = __csv_to_dicts__(test_data)
         self.res_bodies = res_bodies
-        self.ids        = [test_datum['ID'] for test_datum in self.test_data]
-        self.questions  = [test_datum['Question'] for test_datum in self.test_data]
-        self.answers    = [test_datum['Answer'] for test_datum in self.test_data]
-        self.header     = ['ID', 'Test_Data'] + self.ids
+        self.ids = [test_datum['ID'] for test_datum in self.test_data]
+        self.questions = [test_datum['Question']
+                          for test_datum in self.test_data]
+        self.answers = [test_datum['Answer'] for test_datum in self.test_data]
+        self.header = ['ID', 'Test_Data'] + self.ids
 
     def csv(self, f: TextIO) -> None:
         writer = csv.writer(f)
@@ -27,9 +29,9 @@ class ChartDrawer:
         for res_body in self.res_bodies:
             _score_tables = list()
             for i in range(len(res_body['suggestions'])):
-                score_table         = dict()
-                answer              = res_body['suggestions'][i]['payloads'][0]['text']
-                score               = res_body['suggestions'][i]['confidence']
+                score_table = dict()
+                answer = res_body['suggestions'][i]['payloads'][0]['text']
+                score = res_body['suggestions'][i]['confidence']
                 score_table[answer] = score
                 _score_tables.append(score_table)
             score_tables.append(_score_tables)
@@ -38,11 +40,11 @@ class ChartDrawer:
     def __rows__(self) -> list[list[str]]:
         rows = list()
         for s_tables in self.__score_tables__():
-            scores  = list()
+            scores = list()
             _scores = ['0.0%' * 1 for i in range(len(self.test_data))]
             for s_table in s_tables:
                 for answer, score in s_table.items():
-                    index          = self.answers.index(answer)
+                    index = self.answers.index(answer)
                     _scores[index] = f'{score * 100:.1f}%'
             scores.append(_scores)
             rows.extend(scores)

--- a/python/src/lib/format.py
+++ b/python/src/lib/format.py
@@ -3,6 +3,7 @@ import json
 from typing import Any
 from list_handler import __uniq_list__
 
+
 def __template__() -> dict[str, Any]:
     return {
         'id': '',
@@ -13,13 +14,14 @@ def __template__() -> dict[str, Any]:
             'answers': {
                 'ja': ['']
             },
-        'questions': {
-            'ja': []
-        },
-        'redirectFlow': '',
-        'redirectNode': ''
+            'questions': {
+                'ja': []
+            },
+            'redirectFlow': '',
+            'redirectNode': ''
         }
     }
+
 
 def __to_json__(csv_training_data: str) -> str:
     result = list()
@@ -29,13 +31,18 @@ def __to_json__(csv_training_data: str) -> str:
         training_data = csv.DictReader(f)
         for training_datum in training_data:
             if format['data']['answers']['ja'][-1] == training_datum['Answer']:
-                format['data']['questions']['ja'].append(training_datum['Question'])
+                format['data']['questions']['ja'].append(
+                    training_datum['Question'])
             else:
-                format       = __template__()
+                format = __template__()
                 format['id'] = training_datum['ID']
-                format['data']['questions']['ja'].append(training_datum['Question'])
+                format['data']['questions']['ja'].append(
+                    training_datum['Question'])
                 format['data']['answers']['ja'].remove('')
-                format['data']['answers']['ja'].append(training_datum['Answer'])
-            format['data']['questions']['ja'] = __uniq_list__(format['data']['questions']['ja'])
+                format['data']['answers']['ja'].append(
+                    training_datum['Answer'])
+            format['data']['questions']['ja'] = __uniq_list__(
+                format['data']['questions']['ja'])
             result.append(format)
-    return json.dumps({ 'qnas': __uniq_list__(result) }, ensure_ascii = False, indent = 2)
+    return json.dumps({'qnas': __uniq_list__(result)},
+                      ensure_ascii=False, indent=2)

--- a/python/src/lib/list_handler.py
+++ b/python/src/lib/list_handler.py
@@ -1,15 +1,17 @@
 import csv
 
+
 def __uniq_list__(data: list) -> list:
     result = list()
     for datum in data:
-        if not datum in result:
+        if datum not in result:
             result.append(datum)
     return result
+
 
 def __csv_to_dicts__(csv_file: str) -> list[dict[str, str]]:
     data = None
     with open(csv_file) as f:
         reader = csv.DictReader(f)
-        data   = [datum for datum in reader]
+        data = [datum for datum in reader]
     return data

--- a/python/src/queries/accuracy_check_query.py
+++ b/python/src/queries/accuracy_check_query.py
@@ -7,14 +7,21 @@ from list_handler import __csv_to_dicts__
 
 INVALID_PATTERNS = r'[\\\'\|\`\^\"\<\>\)\(\}\{\]\[\;\/\?\:\@\&\=\+\$\,\%\# ]'
 
+
 class AccuracyCheckQuery:
-    def __init__(self, scheme: str, host: str, bot_id: str, user_id: str, test_data: str) -> None:
-        self.scheme    = re.sub(INVALID_PATTERNS, '', scheme)
-        self.host      = re.sub(INVALID_PATTERNS, '', host)
-        self.bot_id    = re.sub(INVALID_PATTERNS, '', bot_id)
-        self.user_id   = re.sub(INVALID_PATTERNS, '', user_id)
+    def __init__(
+            self,
+            scheme: str,
+            host: str,
+            bot_id: str,
+            user_id: str,
+            test_data: str) -> None:
+        self.scheme = re.sub(INVALID_PATTERNS, '', scheme)
+        self.host = re.sub(INVALID_PATTERNS, '', host)
+        self.bot_id = re.sub(INVALID_PATTERNS, '', bot_id)
+        self.user_id = re.sub(INVALID_PATTERNS, '', user_id)
         self.test_data = __csv_to_dicts__(test_data)
-        self.uri       = f'{self.scheme}://{self.host}/api/v1/bots/{self.bot_id}/converse/{self.user_id}/secured?include=suggestions'
+        self.uri = f'{self.scheme}://{self.host}/api/v1/bots/{self.bot_id}/converse/{self.user_id}/secured?include=suggestions'
 
     def res_bodies(self) -> list[dict[str, Any]]:
         return [json.loads(res_body.read()) for res_body in self.__request__()]
@@ -32,7 +39,8 @@ class AccuracyCheckQuery:
                 'type': 'text',
                 'text': test_datum['Question']
             }
-            req = urllib.request.Request(self.uri, json.dumps(body).encode(), header)
+            req = urllib.request.Request(
+                self.uri, json.dumps(body).encode(), header)
             res = urllib.request.urlopen(req)
             responses.append(res)
         return responses

--- a/python/src/training_data.py
+++ b/python/src/training_data.py
@@ -1,8 +1,9 @@
+from format import __to_json__
 import os
 import datetime
 import sys
 sys.path.append('./src/lib')
-from format import __to_json__
+
 
 class TrainingData:
     def __init__(self, training_data: str) -> None:
@@ -15,4 +16,6 @@ class TrainingData:
     # private
 
     def __filename__(self, dirname: str) -> str:
-        return os.path.join(dirname, f'training_data_{datetime.datetime.now():%Y%m%d%H%M%S}.json')
+        return os.path.join(
+            dirname, f'training_data_{
+                datetime.datetime.now():%Y%m%d%H%M%S}.json')

--- a/python/test/lib/test_chart_drawer.py
+++ b/python/test/lib/test_chart_drawer.py
@@ -1,6 +1,3 @@
-from test_application import TestApplication
-from list_handler import __csv_to_dicts__
-from chart_drawer import ChartDrawer
 import unittest
 import os
 import datetime
@@ -8,6 +5,9 @@ import json
 import sys
 sys.path.append('./src/lib')
 sys.path.append('./test')
+from test_application import TestApplication
+from list_handler import __csv_to_dicts__
+from chart_drawer import ChartDrawer
 
 
 class TestChartDrawer(TestApplication):

--- a/python/test/lib/test_chart_drawer.py
+++ b/python/test/lib/test_chart_drawer.py
@@ -1,3 +1,6 @@
+from test_application import TestApplication
+from list_handler import __csv_to_dicts__
+from chart_drawer import ChartDrawer
 import unittest
 import os
 import datetime
@@ -5,27 +8,28 @@ import json
 import sys
 sys.path.append('./src/lib')
 sys.path.append('./test')
-from chart_drawer import ChartDrawer
-from list_handler import __csv_to_dicts__
-from test_application import TestApplication
+
 
 class TestChartDrawer(TestApplication):
     def setUp(self) -> None:
         super().setUp()
-        self.csv_path   = os.path.join('..', 'csv', 'test_data.csv')
-        json_path       = os.path.join('..', 'json', 'res_bodies.json')
+        self.csv_path = os.path.join('..', 'csv', 'test_data.csv')
+        json_path = os.path.join('..', 'json', 'res_bodies.json')
         self.res_bodies = None
         with open(json_path) as f:
             self.res_bodies = json.loads(f.read())
         self.chart_drawer = ChartDrawer(self.csv_path, self.res_bodies)
 
     def test_csv(self) -> None:
-        filename = os.path.join(self.dirname, f'accuracy_score_chart_{datetime.datetime.now():%Y%m%d%H%M%S}.csv')
+        filename = os.path.join(
+            self.dirname, f'accuracy_score_chart_{
+                datetime.datetime.now():%Y%m%d%H%M%S}.csv')
         with open(filename, 'w') as f:
             self.chart_drawer.csv(f)
         test_data = __csv_to_dicts__(self.csv_path)
         csv_chart = __csv_to_dicts__(filename)
         self.assertEqual(len(csv_chart), len(test_data))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_application.py
+++ b/python/test/test_application.py
@@ -3,11 +3,17 @@ import os
 import shutil
 import glob
 
+
 class TestApplication(unittest.TestCase):
     def setUp(self) -> None:
-        self.dirname  = os.path.join('test', 'tmp')
-        self.pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
-        os.makedirs(self.dirname, exist_ok = True)
+        self.dirname = os.path.join('test', 'tmp')
+        self.pycaches = glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True)
+        os.makedirs(self.dirname, exist_ok=True)
 
     def tearDown(self) -> None:
         if os.path.exists(self.dirname):
@@ -15,6 +21,7 @@ class TestApplication(unittest.TestCase):
         for pycache in self.pycaches:
             if os.path.exists(pycache):
                 shutil.rmtree(pycache)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_training_data.py
+++ b/python/test/test_training_data.py
@@ -1,10 +1,11 @@
+from test_application import TestApplication
+from training_data import TrainingData
 import unittest
 import os
 import glob
 import sys
 sys.path.append('./src')
-from training_data import TrainingData
-from test_application import TestApplication
+
 
 class TestTrainingData(TestApplication):
     def setUp(self) -> None:
@@ -15,6 +16,7 @@ class TestTrainingData(TestApplication):
     def test_export(self) -> None:
         self.training_data.export(self.dirname)
         self.assertTrue(any(glob.glob(f'{self.dirname}/training_data*.json')))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_training_data.py
+++ b/python/test/test_training_data.py
@@ -1,10 +1,10 @@
-from test_application import TestApplication
-from training_data import TrainingData
 import unittest
 import os
 import glob
 import sys
 sys.path.append('./src')
+from test_application import TestApplication
+from training_data import TrainingData
 
 
 class TestTrainingData(TestApplication):


### PR DESCRIPTION
## 1. Overview

This project makes use of [flake8](https://pypi.org/project/flake8/) as an inspector of violations against Python syntax and convention.
However, it does not fix them, so some other libraries need installing, which are [autoflake8](https://pypi.org/project/autoflake8/) and [autopep8](https://pypi.org/project/autopep8/)

## 2. Commit

- [Install lint-fix library and update dependencies](https://github.com/hayat01sh1da/botpress-accuracy-checkers/commit/46eb457945fb8008bbc98de82b8e2876cd15e1a0)
- [Execute lint fixed with autopep8](https://github.com/hayat01sh1da/botpress-accuracy-checkers/commit/3d4b576db747a142cf13c1ff044a4bfe2fdcda3b)
- [Move module imports to the top of the file in order to comply with PEP 8 guidelines](https://github.com/hayat01sh1da/botpress-accuracy-checkers/pull/128/changes/321d760e7946815cf41c57430c9170154ec2cc93)