### PR TITLE
[python] Install Type Checking

### DIFF
--- a/python/requirements.lock
+++ b/python/requirements.lock
@@ -1,9 +1,9 @@
-ast_serialize==0.3.0
+ast_serialize==0.5.0
 autoflake8==0.4.1
 autopep8==2.3.2
 flake8==7.3.0
 iniconfig==2.3.0
-librt==0.10.0
+librt==0.11.0
 mccabe==0.7.0
 mypy==2.0.0
 mypy_extensions==1.1.0

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-import glob
+import re
 import os
 import shutil
 import sys
@@ -12,17 +12,13 @@ sys.path.append('./src/queries')
 
 @pytest.fixture(autouse=True)
 def __cleanup_caches__() -> Iterator[None]:
-    caches = set(
-        glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '.*py.*cache.*'),
-            recursive=True))
     yield
-    for cache in caches:
-        if os.path.exists(cache):
-            shutil.rmtree(cache)
+    cache_dir = re.compile(r'^(?:__pycache__|\.pytest_cache|\.mypy_cache)$')
+    for root, dirs, _ in os.walk('.'):
+        for name in list(dirs):
+            if cache_dir.match(name):
+                shutil.rmtree(os.path.join(root, name), ignore_errors=True)
+                dirs.remove(name)
 
 
 @pytest.fixture

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,3 +1,4 @@
+import pytest
 import glob
 import os
 import shutil
@@ -9,16 +10,19 @@ sys.path.append('./src/lib')
 sys.path.append('./src/queries')
 
 
-import pytest
-
-
 @pytest.fixture(autouse=True)
-def _cleanup_pycaches() -> Iterator[None]:
-    before = set(glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True))
+def __cleanup_caches__() -> Iterator[None]:
+    caches = set(
+        glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '.*py.*cache.*'),
+            recursive=True))
     yield
-    for pycache in before:
-        if os.path.exists(pycache):
-            shutil.rmtree(pycache)
+    for cache in caches:
+        if os.path.exists(cache):
+            shutil.rmtree(cache)
 
 
 @pytest.fixture

--- a/python/test/lib/test_chart_drawer.py
+++ b/python/test/lib/test_chart_drawer.py
@@ -13,8 +13,8 @@ def test_csv(tmp_dir: str) -> None:
     chart_drawer = ChartDrawer(csv_path, res_bodies)
 
     filename = os.path.join(
-        tmp_dir, f'accuracy_score_chart_{datetime.datetime.now():%Y%m%d%H%M%S}.csv',
-    )
+        tmp_dir, f'accuracy_score_chart_{
+            datetime.datetime.now():%Y%m%d%H%M%S}.csv', )
     with open(filename, 'w') as f:
         chart_drawer.csv(f)
 

--- a/python/test/test_application.py
+++ b/python/test/test_application.py
@@ -1,1 +1,2 @@
-# Shared fixtures live in conftest.py; this module currently has no module-level tests.
+# Shared fixtures live in conftest.py; this module currently has no
+# module-level tests.


### PR DESCRIPTION
## 1. Why (Purpose)

Most personal Python projects had no static type checking, and code-style consistency was only partially enforced. The goals were to:

- **Introduce `mypy`** to every Python project so type regressions are caught in CI rather than at runtime.
- **Add reasonable type annotations** to the implementations (and add missing ones where mypy was partially present).
- **Enable the `mypy` job in GitHub Actions** so type checking runs on every push/PR (it was commented out in most workflows).
- **Enforce code convention** by running `autoflake8` + `autopep8` and fixing residual `flake8` violations, keeping the codebase clean and consistent.

## 2. What (Procedures)

Processed **13 Python repositories** (the `github-wiki-organisers-wiki` repo was skipped — the project is a git submodule there). Per project:

1. Ensured `mypy==2.0.0` in `requirements.txt` (added to `deep-learnings`, `natural-language-processing`).
2. Added a `[tool.mypy]` block in `pyproject.toml` (created where missing).
3. Added type annotations across `src/`, `test/`, `conftest.py`, `main.py`, `exec/` so `mypy` passes; fixed genuine type bugs found along the way (`*_` argv-unpack reuse, a literally-duplicated class in `embedding_dot.py`, a duplicated optional-import block, a missing `import urllib.parse`, `from X import *` → explicit imports).
4. Enabled the previously-commented `mypy` CI job; added `run_mypy.sh` for multi-subproject/volume repos to avoid duplicate-module collisions.
5. Ran `autoflake8 --in-place --remove-duplicate-keys --remove-unused-variables --recursive .` and `autopep8 --in-place --aggressive --aggressive --recursive .`, then fixed remaining `flake8` violations (E501, E402, E114/E131, F811, F403/F405).
6. Verified each unit with `mypy`, `flake8` (project CI settings), and `pytest`.

**Strictness policy:** application projects use strict config (`disallow_untyped_defs = true`, matching the existing `file-cleaners` convention); the numpy/learning repos (`tutorials`, `natural-language-processing`, `deep-learnings`) use a lenient config — mirroring the user's own pre-existing lenient `deep-learnings` setup.

**Commits:** two semantic units per repo on the existing topic branch, local only — *“Introduce mypy type checking”* (config/deps/CI/`run_mypy.sh`) and *“Apply autoflake8/autopep8 and fix flake8 violations”* (source pass). Repos already mypy-enabled got only the second commit.

A separate follow-up fix: `save_dicision_boundary_image` (deep-learnings vol2) didn’t open a fresh matplotlib figure, so it rendered onto the leftover loss-plot figure when the test suite ran in one process — corrupting `img/dicision_boundary.png`. Added `plt.figure()` and restored the curated original PNGs (commit `00ed73c`).

## 3. How (Operation and Maintenance)

- **Toolchain:** Windows had no usable Python; the toolchain (Python 3.14, mypy 2.0, flake8, autopep8, autoflake8, pytest) runs under **WSL Ubuntu**. Run all checks there against `/mnt/c/...`.
- **Run type checks:** single-unit projects — `mypy .` from the project dir. `coding-tests` — `bash run_mypy.sh` from `python/` (iterates the 5 subprojects). `deep-learnings` — `bash run_mypy.sh vol1|vol2` from repo root (root `pyproject.toml` config applies); `vol3` is checked per-chapter (intentionally reused module basenames, same reason pytest uses `--import-mode=importlib`).
- **Lint maintenance:** re-run the mandated `autoflake8`/`autopep8` pair, then `flake8 . --max-complexity=10 --max-line-length=127`.
- **CI:** `mypy` jobs are now active in the workflows; pushing the topic branches will exercise them on GitHub.
- **Caveat for maintainers:** several deep-learnings tests `savefig` directly into the tracked `img/` directory, so a full test run rewrites those committed PNGs (now correctly, after the figure fix). Consider redirecting test image output to a temp/untracked path.

## 4. Pros & Cons

### Pros

- Static type safety now enforced in CI across all projects; many latent bugs surfaced and fixed.
- Consistent, convention-compliant formatting; clean `flake8`/`mypy`/`pytest` across the board.
- Per-repo, semantically split commits make review and selective reverts easy.
- Pragmatic per-domain strictness keeps numpy/learning code maintainable without low-value churn.

### Cons & Trade-offs

- A few targeted `# type: ignore` for genuine pre-existing oddities (e.g. `list - dict_keys` valid only via `Set.__rsub__`); not full type purity.
- Type annotations and `autopep8` reflow are interleaved in the same files, so the two semantic commits split at the infra-vs-source boundary rather than purely "types vs lint".
- `autopep8 --aggressive --aggressive` produced some visually awkward wrapping (e.g. multi-line f-strings) — functional but not hand-tuned.
- `deep-learnings/vol2/train/` & `vol2/evaluate/` are pre-existing broken, non-tested experiment scripts — excluded from mypy rather than rewritten.

## 5. Others

- **Skipped:** `github-wiki-organisers-wiki` (the project is a git submodule of the `.wiki` repo — editing it would be wrong).
- **Nothing pushed** — all commits are local on the `hayat01sh1da/python/install-type-checking` topic branch in each repo, per request.
- **Pre-existing, out-of-scope issue flagged:** `natural-language-processing/.github/workflows/1_prereqiosotes.yml` has inconsistent path filters/filename (`vol1/**` vs `1_prerequisites`); left unchanged.
- **Environment-dependent tests:** `web-scrapers` (chromedriver) and `calculator_cli_app` (`CALCULATION_API`) passed in the WSL env but depend on external setup in CI.
- **Verification results:** all units green — e.g. github-wiki-organisers (mypy 14, pytest 32), web-scrapers (mypy 17, pytest 8), coding-tests (pytest 200/2/80/3/4), deep-learnings (mypy 42/108/all-chapters, pytest 48/153/15).