### PR TITLE
[ruby][ruby-on-rails] Update Gem Dependencies

### DIFF
--- a/ruby-on-rails/Gemfile
+++ b/ruby-on-rails/Gemfile
@@ -45,6 +45,7 @@ group :development do
   gem 'rubocop-performance', '~> 1.26.0', require: false
   gem 'rubocop-rails', '~> 2.35.1', require: false
   gem 'rubocop-rspec', '~> 3.9.0', require: false
+  gem 'rubocop-rspec_rails', '~> 2.32.0', require: false
   # Typechecking
   gem 'rbs-inline', '~> 0.14.0', require: false
   gem 'rbs_rails', '~> 0.13.1', require: false

--- a/ruby-on-rails/Gemfile
+++ b/ruby-on-rails/Gemfile
@@ -15,7 +15,7 @@ gem 'dotenv-rails', '~> 3.2.0'
 gem 'rexml', '~> 3.4.4'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '~> 1.24.1', require: false
+gem 'bootsnap', '~> 1.24.4', require: false
 
 # CSV
 gem 'csv', '~> 3.3.5'
@@ -41,14 +41,14 @@ group :development do
   # Static code analysis for security vulnerabilities
   gem 'brakeman', '~> 8.0.4', require: false
   # RuboCop
-  gem 'rubocop', '~> 1.86.1', require: false
+  gem 'rubocop', '~> 1.86.2', require: false
   gem 'rubocop-performance', '~> 1.26.0', require: false
-  gem 'rubocop-rails', '~> 2.34.3', require: false
+  gem 'rubocop-rails', '~> 2.35.1', require: false
   gem 'rubocop-rspec', '~> 3.9.0', require: false
   # Typechecking
-  gem 'rbs-inline', '~> 0.13.0', require: false
+  gem 'rbs-inline', '~> 0.14.0', require: false
   gem 'rbs_rails', '~> 0.13.1', require: false
-  gem 'steep', '~> 1.10.0', require: false
+  gem 'steep', '~> 2.0.0', require: false
 end
 
 group :test do

--- a/ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    action_text-trix (2.1.18)
+    action_text-trix (2.1.19)
       railties
     actioncable (8.1.3)
       actionpack (= 8.1.3)
@@ -79,7 +79,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    bootsnap (1.24.1)
+    bootsnap (1.24.4)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc
@@ -135,7 +135,6 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
-    mutex_m (0.3.0)
     net-imap (0.6.4)
       date
       net-protocol
@@ -208,12 +207,13 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.10.4)
+    rbs (4.0.2)
       logger
+      prism (>= 1.6.0)
       tsort
-    rbs-inline (0.13.0)
+    rbs-inline (0.14.0)
       prism (>= 0.29)
-      rbs (>= 3.8.0)
+      rbs (~> 4.0)
     rbs_rails (0.13.1)
       parser
       prism
@@ -243,7 +243,7 @@ GEM
       rspec-mocks (>= 3.13.0, < 5.0.0)
       rspec-support (>= 3.13.0, < 5.0.0)
     rspec-support (3.13.7)
-    rubocop (1.86.1)
+    rubocop (1.86.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -261,7 +261,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.34.3)
+    rubocop-rails (2.35.1)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -280,8 +280,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    steep (1.10.0)
-      activesupport (>= 5.1)
+    steep (2.0.0)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
       fileutils (>= 1.1.0)
@@ -289,10 +288,10 @@ GEM
       language_server-protocol (>= 3.17.0.4, < 4.0)
       listen (~> 3.0)
       logger (>= 1.3.0)
-      mutex_m (>= 0.3.0)
-      parser (>= 3.1)
+      parser (>= 3.2)
+      prism (>= 0.25.0)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 3.9)
+      rbs (~> 4.0)
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 5)
@@ -319,13 +318,13 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.7.5)
+    zeitwerk (2.8.0)
 
 PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  bootsnap (~> 1.24.1)
+  bootsnap (~> 1.24.4)
   brakeman (~> 8.0.4)
   csv (~> 3.3.5)
   debug
@@ -334,21 +333,21 @@ DEPENDENCIES
   puma (~> 8.0.1)
   rack-mini-profiler (~> 4.0.1)
   rails (~> 8.1.3)
-  rbs-inline (~> 0.13.0)
+  rbs-inline (~> 0.14.0)
   rbs_rails (~> 0.13.1)
   rexml (~> 3.4.4)
   rspec-rails (~> 8.0.4)
-  rubocop (~> 1.86.1)
+  rubocop (~> 1.86.2)
   rubocop-performance (~> 1.26.0)
-  rubocop-rails (~> 2.34.3)
+  rubocop-rails (~> 2.35.1)
   rubocop-rspec (~> 3.9.0)
   sprockets-rails (~> 3.5.2)
-  steep (~> 1.10.0)
+  steep (~> 2.0.0)
   tzinfo-data
   web-console (~> 4.3.0)
 
 CHECKSUMS
-  action_text-trix (2.1.18) sha256=3fdb83f8bff4145d098be283cdd47ac41caf5110bfa6df4695ed7127d7fb3642
+  action_text-trix (2.1.19) sha256=7012f59421009cf284aa651294896414d653a61a2417c9b8714c8476d2f74009
   actioncable (8.1.3) sha256=e5bc7f75e44e6a22de29c4f43176927c3a9ce4824464b74ed18d8226e75a80f0
   actionmailbox (8.1.3) sha256=df7da474eaa0e70df4ed5a6fef66eb3b3b0f2dbf7f14518deee8d77f1b4aae59
   actionmailer (8.1.3) sha256=831f724891bb70d0aaa4d76581a6321124b6a752cb655c9346aae5479318448d
@@ -364,7 +363,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
-  bootsnap (1.24.1) sha256=d7faea1dc24aa5b22dacc049c9236b64ebf60b14dd49c615e15d8402375d39ef
+  bootsnap (1.24.4) sha256=a4d939fc2cc5242a83d3a7cb4fb97743ac58475afe91e0600479a3df6f117541
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
@@ -397,7 +396,6 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
-  mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
   net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
@@ -426,8 +424,8 @@ CHECKSUMS
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
-  rbs (3.10.4) sha256=b17d7c4be4bb31a11a3b529830f0aa206a807ca42f2e7921a3027dfc6b7e5ce8
-  rbs-inline (0.13.0) sha256=aba6e48c2d1b75276e8557376164f4b4ba96dd0204e779a5cee2af442bd30442
+  rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25
+  rbs-inline (0.14.0) sha256=eaf47b46690d63acddab1f6804c9cc205a4bc78e637cfc421a0b1239874ef51c
   rbs_rails (0.13.1) sha256=fc83e1f194a4e7fe46e8655e2771c3a00dd829124ae71f9b696cc151b085507e
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
@@ -438,16 +436,16 @@ CHECKSUMS
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
   rspec-rails (8.0.4) sha256=06235692fc0892683d3d34977e081db867434b3a24ae0dd0c6f3516bad4e22df
   rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
-  rubocop (1.86.1) sha256=44415f3f01d01a21e01132248d2fd0867572475b566ca188a0a42133a08d4531
+  rubocop (1.86.2) sha256=bb2e97f635eda42c448f2588f4a6ff78f221b8bdfdf65b1e9b07fbd57521b45d
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
-  rubocop-rails (2.34.3) sha256=10d37989024865ecda8199f311f3faca990143fbac967de943f88aca11eb9ad2
+  rubocop-rails (2.35.1) sha256=4ad270f5fb968ce86ac19f53c4b97354e4f91bc5334177478238674f51568377
   rubocop-rspec (3.9.0) sha256=8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   sprockets (4.2.2) sha256=761e5a49f1c288704763f73139763564c845a8f856d52fba013458f8af1b59b1
   sprockets-rails (3.5.2) sha256=a9e88e6ce9f8c912d349aa5401509165ec42326baf9e942a85de4b76dbc4119e
-  steep (1.10.0) sha256=1b295b55f9aaff1b8d3ee42453ee55bc2a1078fda0268f288edb2dc014f4d7d1
+  steep (2.0.0) sha256=6eb0ecc09637bbb54f0a5f2cf63daea6d3208ccace64b4f1107d976333605c30
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   strscan (3.1.8) sha256=aae2db611a225559f21ffbb71765c9a4e60fd262534a9ea84f4f11c7f32f679e
   terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
@@ -462,7 +460,7 @@ CHECKSUMS
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
-  zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
+  zeitwerk (2.8.0) sha256=474d0a1d2429f635af7c4574f5ddbce0d0cfc286067c7515858b93a26b4f3e3d
 
 RUBY VERSION
   ruby 4.0.4

--- a/ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/Gemfile.lock
@@ -270,6 +270,10 @@ GEM
     rubocop-rspec (3.9.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.81)
+    rubocop-rspec_rails (2.32.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
+      rubocop-rspec (~> 3.5)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     sprockets (4.2.2)
@@ -341,6 +345,7 @@ DEPENDENCIES
   rubocop-performance (~> 1.26.0)
   rubocop-rails (~> 2.35.1)
   rubocop-rspec (~> 3.9.0)
+  rubocop-rspec_rails (~> 2.32.0)
   sprockets-rails (~> 3.5.2)
   steep (~> 2.0.0)
   tzinfo-data
@@ -441,6 +446,7 @@ CHECKSUMS
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
   rubocop-rails (2.35.1) sha256=4ad270f5fb968ce86ac19f53c4b97354e4f91bc5334177478238674f51568377
   rubocop-rspec (3.9.0) sha256=8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2
+  rubocop-rspec_rails (2.32.0) sha256=4a0d641c72f6ebb957534f539d9d0a62c47abd8ce0d0aeee1ef4701e892a9100
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   sprockets (4.2.2) sha256=761e5a49f1c288704763f73139763564c845a8f856d52fba013458f8af1b59b1

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'rbs-inline', '~> 0.13.0', require: false
-gem 'rubocop', '~> 1.86.1', require: false
+gem 'rbs-inline', '~> 0.14.0', require: false
+gem 'rubocop', '~> 1.86.2', require: false
 gem 'rubocop-minitest', '~> 0.39.1', require: false
 gem 'rubocop-performance', '~> 1.26.1', require: false
 gem 'steep', '~> 2.0.0', require: false

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -38,11 +38,11 @@ GEM
       logger
       prism (>= 1.6.0)
       tsort
-    rbs-inline (0.13.0)
+    rbs-inline (0.14.0)
       prism (>= 0.29)
-      rbs (>= 3.8.0)
+      rbs (~> 4.0)
     regexp_parser (2.12.0)
-    rubocop (1.86.1)
+    rubocop (1.86.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -105,8 +105,8 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  rbs-inline (~> 0.13.0)
-  rubocop (~> 1.86.1)
+  rbs-inline (~> 0.14.0)
+  rubocop (~> 1.86.2)
   rubocop-minitest (~> 0.39.1)
   rubocop-performance (~> 1.26.1)
   steep (~> 2.0.0)
@@ -141,9 +141,9 @@ CHECKSUMS
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
   rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25
-  rbs-inline (0.13.0) sha256=aba6e48c2d1b75276e8557376164f4b4ba96dd0204e779a5cee2af442bd30442
+  rbs-inline (0.14.0) sha256=eaf47b46690d63acddab1f6804c9cc205a4bc78e637cfc421a0b1239874ef51c
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
-  rubocop (1.86.1) sha256=44415f3f01d01a21e01132248d2fd0867572475b566ca188a0a42133a08d4531
+  rubocop (1.86.2) sha256=bb2e97f635eda42c448f2588f4a6ff78f221b8bdfdf65b1e9b07fbd57521b45d
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   rubocop-minitest (0.39.1) sha256=998398d6da4026d297f0f9bf709a1eac5f2b6947c24431f94af08138510cf7ed
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834


### PR DESCRIPTION
## 1. Overview

This PR bumps linting / type-checking tooling (and their transitive dependencies) across two project directories.  
The headline change is the **major upgrade of the RBS / Steep type-checking stack** (RBS 3 → 4, Steep 1 → 2), which drops the `mutex_m` shim and pulls in the Prism parser.

Legend — **Kind**: `patch` = bug-fix only, `minor` = backward-compatible features, `major` = breaking changes, `added` / `removed` = dependency appeared / disappeared in the lockfile.

## 2. `ruby/` directory

In this directory `rbs` was already at **4.0.2**, so only the two tools that track it changed.

| Gem | Before | After | Kind | Notes |
|---|---|---|---|---|
| rbs-inline | 0.13.0 | 0.14.0 | minor | Dependency constraint tightened from `rbs (>= 3.8.0)` to `rbs (~> 4.0)`. |
| rubocop | 1.86.1 | 1.86.2 | patch | Bug-fix release. |

## 3. `ruby-on-rails/` directory

| Gem | Before | After | Kind | Notes |
|---|---|---|---|---|
| **rbs** | 3.10.4 | 4.0.2 | **major** | RBS 4.x; now declares `prism (>= 1.6.0)` as a runtime dependency (Prism is now the parser). API/signature breaking changes. |
| **steep** | 1.10.0 | 2.0.0 | **major** | Steep 2.x; requires `rbs (~> 4.0)`, `parser (>= 3.2)`, adds `prism (>= 0.25.0)`, and **drops** its `activesupport` and `mutex_m` dependencies. |
| rbs-inline | 0.13.0 | 0.14.0 | minor | Now requires `rbs (~> 4.0)` (was `rbs (>= 3.8.0)`) — moves in lock-step with the RBS 4 upgrade. |
| rubocop | 1.86.1 | 1.86.2 | patch | Bug-fix release. |
| rubocop-rails | 2.34.3 | 2.35.1 | minor | New/updated cops and fixes. |
| rubocop-rspec_rails | — | 2.32.0 | **added** | Newly declared dev dependency (RSpec-Rails cops extracted into their own gem; depends on `rubocop-rspec (~> 3.5)`). |
| bootsnap | 1.24.1 | 1.24.4 | patch | Three patch releases of bug fixes. |
| action_text-trix | 2.1.18 | 2.1.19 | patch | Bundled Trix editor patch update. |
| zeitwerk | 2.7.5 | 2.8.0 | minor | Maintenance/feature release of the code loader. |
| mutex_m | 0.3.0 | — | **removed** | No longer needed once Steep 2.0 dropped its `mutex_m` dependency (it was the only consumer). |

## 4. Summary

- **2 major upgrades**: `rbs` (3 → 4) and `steep` (1 → 2) — coordinated type-checking stack migration onto the Prism parser.
- **1 new gem**: `rubocop-rspec_rails`.
- **1 gem removed**: `mutex_m` (transitively dropped via Steep 2.0).
- Everything else is routine patch/minor maintenance of the RuboCop and boot/loader tooling.