### PR TITLE
[ruby-on-rails] Bump Docker to 29.5.2

### DIFF
--- a/ruby-on-rails/README.md
+++ b/ruby-on-rails/README.md
@@ -4,7 +4,7 @@
 - Ruby 4.0.5
 - Gemfile 4.0.12
 - Bundler 4.0.12
-- Docker 29.4.3
+- Docker 29.5.2
 
 ## 2. Setup Docker
 


### PR DESCRIPTION
## 1. Overview

The primary difference between Docker 29.4.3 and 29.5.2 is that version 29.5.2 includes a critical regression fix for the `docker cp` command and updates to the Docker Engine API milestones.

## 2. Key Differences

- **Regression Fix in 29.5.2**: Version 29.5.2 specifically fixes a bug introduced in the 29.5.x branch (specifically 29.5.1) where the `docker cp` command would fail with a `mkdirat: file exists error`
  - This occurred when a container had a bind mount whose target traversed an in-container symlink (e.g., `/var/run` pointing to `/run`)
- **API Milestones**: Version 29.5.2 is associated with newer GitHub milestones for both the [Docker CLI](https://docs.docker.com/engine/release-notes/29/) and Moby compared to the 29.4.x series
- Version Hierarchy
  - 29.4.3: A stable patch release in the 29.4 release line, focusing on dependencies and minor stability
  - 29.5.2: The latest patch release in the 29.5 minor release line, which followed the 29.4 series to introduce further enhancements and subsequent bug fixes

## 3. Shared Features (Docker 29 Series)

Both versions are part of the **Docker 29** major release, which introduced several significant changes to the ecosystem:

- **Raised Minimum API**: Docker 29 increased the minimum supported [Docker Engine API](https://docs.docker.com/reference/api/engine/) version to **1.44**
  - This caused compatibility issues with older clients like certain versions of Portainer, Traefik, and Watchtower
- **Internal Improvements:** Continued evolution of the image store leveraging [containerd](https://www.docker.com/blog/docker-engine-version-29/) capabilities and the removal of the deprecated graph driver backend in favor of snapshotters

## 4. References

- [Docker Engine version 29 release notes](https://docs.docker.com/engine/release-notes/29/)
- [Releases · docker/compose - GitHub](https://github.com/docker/compose/releases)
- [Docker 29 increased minimum API version, breaks Traefik reverse proxy](https://forums.docker.com/t/docker-29-increased-minimum-api-version-breaks-traefik-reverse-proxy/150384)
- [Docker Engine v29 Release](https://www.docker.com/blog/docker-engine-version-29/)