### PR TITLE
[ruby-on-rails] Update Gem Dependencies

### DIFF
--- a/ruby-on-rails/Dockerfile
+++ b/ruby-on-rails/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:4.0.5
 # Packages
 RUN apt-get update && apt-get install -y curl build-essential libpq-dev libvips libvips-dev vim tree
 
-ARG BUNDLER_VERSION=4.0.12
+ARG BUNDLER_VERSION=4.0.13
 
 WORKDIR /tmp
 

--- a/ruby-on-rails/Gemfile
+++ b/ruby-on-rails/Gemfile
@@ -17,7 +17,7 @@ gem 'dotenv-rails', '~> 3.2.0'
 gem 'rexml', '~> 3.4.4'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '~> 1.24.5', require: false
+gem 'bootsnap', '~> 1.24.6', require: false
 
 # CSV
 gem 'csv', '~> 3.3.5'

--- a/ruby-on-rails/Gemfile
+++ b/ruby-on-rails/Gemfile
@@ -25,6 +25,10 @@ gem 'csv', '~> 3.3.5'
 # Data structure, similar to a Hash, that allows the definition of arbitrary attributes with their accompanying values
 gem 'ostruct', '~> 0.6.3'
 
+# CGI: used transitively by Rails (cookie/session escaping). Formerly a default
+# gem; pinned explicitly so Bundler/RBS can resolve it from Gemfile.lock.
+gem 'cgi', '~> 0.5.0'
+
 group :development, :test do
   # Debug tool used with binding.irb. Explicit require avoids eager loading `debug/prelude`
   # which interferes with the Docker boot process.

--- a/ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     brakeman (8.0.4)
       racc
     builder (3.3.0)
+    cgi (0.5.1)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
@@ -261,7 +262,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.35.3)
+    rubocop-rails (2.35.4)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -330,6 +331,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (~> 1.24.6)
   brakeman (~> 8.0.4)
+  cgi (~> 0.5.0)
   csv (~> 3.3.5)
   debug
   dotenv-rails (~> 3.2.0)
@@ -372,6 +374,7 @@ CHECKSUMS
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
+  cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
@@ -444,7 +447,7 @@ CHECKSUMS
   rubocop (1.86.2) sha256=bb2e97f635eda42c448f2588f4a6ff78f221b8bdfdf65b1e9b07fbd57521b45d
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
-  rubocop-rails (2.35.3) sha256=6edd45410866912b9b2e90ae3aeafd31d576df2bb2a9c9408f1667a50c32c7de
+  rubocop-rails (2.35.4) sha256=3aeaa325439c89950e8327565682ea794065d08e2ecbbfe95032bfa295a35df5
   rubocop-rspec (3.9.0) sha256=8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2
   rubocop-rspec_rails (2.32.0) sha256=4a0d641c72f6ebb957534f539d9d0a62c47abd8ce0d0aeee1ef4701e892a9100
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33

--- a/ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    bootsnap (1.24.5)
+    bootsnap (1.24.6)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc
@@ -112,7 +112,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.19.7)
+    json (2.19.8)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.10.0)
@@ -156,7 +156,7 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
-    psych (5.3.1)
+    psych (5.4.0)
       date
       stringio
     puma (8.0.2)
@@ -318,7 +318,7 @@ GEM
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.1)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -328,13 +328,13 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  bootsnap (~> 1.24.5)
+  bootsnap (~> 1.24.6)
   brakeman (~> 8.0.4)
   csv (~> 3.3.5)
   debug
   dotenv-rails (~> 3.2.0)
   ostruct (~> 0.6.3)
-  puma (~> 8.0.1)
+  puma (~> 8.0.2)
   rack-mini-profiler (~> 4.0.1)
   rails (~> 8.1.3)
   rbs-inline (~> 0.14.0)
@@ -343,7 +343,7 @@ DEPENDENCIES
   rspec-rails (~> 8.0.4)
   rubocop (~> 1.86.2)
   rubocop-performance (~> 1.26.0)
-  rubocop-rails (~> 2.35.2)
+  rubocop-rails (~> 2.35.3)
   rubocop-rspec (~> 3.9.0)
   rubocop-rspec_rails (~> 2.32.0)
   sprockets-rails (~> 3.5.2)
@@ -368,10 +368,10 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
-  bootsnap (1.24.5) sha256=36b677448524d279b470469aabd5dff4a980e3fa4931a0df68da4a500eb1b6c4
+  bootsnap (1.24.6) sha256=c60bab88c70332290f0a2636a288f675299eb4f804a02a3c085b42eca9da164a
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
+  bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
@@ -390,7 +390,7 @@ CHECKSUMS
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
-  json (2.19.7) sha256=fe432c8639f6efff69f9d73b518a3705d9581ab93156f981ea72806e1e5bcc3e
+  json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
@@ -413,7 +413,7 @@ CHECKSUMS
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
-  psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
+  psych (5.4.0) sha256=14f72d69a611af663d7d70e4a7b67d9eb1f3ae9f8d916b478961d5a0075ba5b7
   puma (8.0.2) sha256=c8ed871dfbbe66448ea9ffd46692342d9804d4071522b52b5331b7b6e7b686fb
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
@@ -464,7 +464,7 @@ CHECKSUMS
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
-  websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
+  websocket-driver (0.8.1) sha256=5ab238238ce230e5d4b262d2be39624c867914eab99171dc4952b58b577c2d96
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
 
@@ -472,4 +472,4 @@ RUBY VERSION
   ruby 4.0.5
 
 BUNDLED WITH
-  4.0.12
+  4.0.13


### PR DESCRIPTION
## 1. Overview

This PR (`botpress-accuracy-reporters` [#149](https://github.com/hayat01sh1da/botpress-accuracy-reporters/pull/149), `[ruby-on-rails] Update Gem Dependencies`, no description) is a small, two-file Ruby dependency refresh of the `ruby-on-rails/` app.  
It **pins `cgi` explicitly** (a former Ruby default gem now being unbundled) and bumps one resolved gem.  
Base branch `master`; changed files: `ruby-on-rails/Gemfile`, `ruby-on-rails/Gemfile.lock`.

## 2. Key Changes

- **`cgi` — added, resolves to `0.5.1`** (direct dependency; `Gemfile`: `gem 'cgi', '~> 0.5.0'`, `Gemfile.lock`: `cgi (0.5.1)`). `cgi` is the Ruby standard-library gem providing HTML/URI escaping, cookie handling and form parsing. It is being **unbundled from Ruby's default gems**, so it must now appear in the `Gemfile` for Bundler (and the RBS type collection) to resolve it; Rails uses it transitively for cookie/session escaping. Release `0.5.1` itself carried a security fix (use of a weak hashing algorithm on sensitive data), `CGI.new` documentation improvements, and JRuby/TruffleRuby test fixes.
- **`rubocop-rails` `2.35.3` → `2.35.4`** (transitive, `Gemfile.lock` only) — three `Rails/StrongParametersExpect` bug fixes: a false positive when `require` receives an array literal (`params.require([:foo, :bar]).permit(:baz)`), an invalid autocorrection for a single dynamic argument (`params.require(:user).permit(permitted_attributes)`), and now allowing `params[:foo].inspect` without flagging an offense.

## 3. Summary

Minimal and low-risk: one newly-pinned default gem (`cgi`, additive — closes an RBS/Bundler resolution gap rather than changing behaviour) and one lint-only patch bump (`rubocop-rails`, dev/CI tooling only).  
No runtime/application code changes; nothing breaking.

## 4. References

- [cgi/Releases > v0.5.1](https://github.com/ruby/cgi/releases)
- [rubocop-rails/CHANGELOG.md > 2.35.4 (2026-06-07)](https://github.com/rubocop/rubocop-rails/blob/master/CHANGELOG.md)
  - [Compare](https://github.com/rubocop/rubocop-rails/compare/v2.35.3...v2.35.4)