### PR TITLE
[ruby-on-rails] Bump RuboCop Rails Dependency from 2.35.3 to 2.35.4

### DIFF
--- a/ruby-on-rails/Gemfile
+++ b/ruby-on-rails/Gemfile
@@ -49,7 +49,7 @@ group :development do
   # RuboCop
   gem 'rubocop', '~> 1.86.2', require: false
   gem 'rubocop-performance', '~> 1.26.0', require: false
-  gem 'rubocop-rails', '~> 2.35.3', require: false
+  gem 'rubocop-rails', '~> 2.35.4', require: false
   gem 'rubocop-rspec', '~> 3.9.0', require: false
   gem 'rubocop-rspec_rails', '~> 2.32.0', require: false
   # Typechecking

--- a/ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/Gemfile.lock
@@ -345,7 +345,7 @@ DEPENDENCIES
   rspec-rails (~> 8.0.4)
   rubocop (~> 1.86.2)
   rubocop-performance (~> 1.26.0)
-  rubocop-rails (~> 2.35.3)
+  rubocop-rails (~> 2.35.4)
   rubocop-rspec (~> 3.9.0)
   rubocop-rspec_rails (~> 2.32.0)
   sprockets-rails (~> 3.5.2)


### PR DESCRIPTION
- Follow up https://github.com/hayat01sh1da/botpress-accuracy-reporters/pull/149