### PR TITLE
[ruby-on-rails] Bump Bundler from 4.0.13 to 4.0.14

### DIFF
--- a/ruby-on-rails/Dockerfile
+++ b/ruby-on-rails/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:4.0.5
 # Packages
 RUN apt-get update && apt-get install -y curl build-essential libpq-dev libvips libvips-dev vim tree
 
-ARG BUNDLER_VERSION=4.0.13
+ARG BUNDLER_VERSION=4.0.14
 
 WORKDIR /tmp
 

--- a/ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/Gemfile.lock
@@ -475,4 +475,4 @@ RUBY VERSION
   ruby 4.0.5
 
 BUNDLED WITH
-  4.0.13
+  4.0.14


### PR DESCRIPTION
## 1. Overview

Bundler 4.0.14 (released 2026-06-10) is a small patch release over 4.0.13.  
It contains no new features — only two bug fixes, both targeting the source "cooldown" behaviour (the mechanism that delays adopting freshly published gem versions).  
No breaking changes; upgrading is safe and recommended.

## 2. Key Changes

**Bug fixes:**

- **Preserve per-source cooldown when converging sources from the lockfile** (PR https://github.com/ruby/rubygems/pull/9601, bryanwoods)
  — When Bundler reconciles the sources declared in the `Gemfile` against those recorded
  in `Gemfile.lock`, the per-source cooldown setting is now retained instead of being lost.
- **Don't exclude the locked version from cooldown during `bundle update`** (PR https://github.com/ruby/rubygems/pull/9599, hsbt)
  — During `bundle update`, the version already pinned in the lockfile is no longer
  wrongly exempted from the cooldown window.

## 3. Summary

A focused bug-fix release.  
Both fixes correct edge cases in how Bundler applies the cooldown policy when resolving and updating dependencies, making cooldown behaviour consistent between `bundle install`/converge and `bundle update`.  
No API, CLI, or configuration changes — a drop-in patch upgrade from 4.0.13.

## 4. References

- [bundler/CHANGELOG.md > 4.0.14 / 2026-06-10](https://github.com/ruby/rubygems/blob/master/bundler/CHANGELOG.md#4014--2026-06-10)
- [Comparing changes between 4.0.13 and 4.0.14](https://github.com/ruby/rubygems/compare/v4.0.13...bundler-v4.0.14)