### PR TITLE
[ruby][ruby-on-rails] Update Gem Dependencies

### DIFF
--- a/ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     cgi (0.5.1)
@@ -113,7 +113,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.19.8)
+    json (2.19.9)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.10.0)
@@ -135,7 +135,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    msgpack (1.8.1)
+    msgpack (1.8.3)
     net-imap (0.6.4.1)
       date
       net-protocol
@@ -371,9 +371,9 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.24.6) sha256=c60bab88c70332290f0a2636a288f675299eb4f804a02a3c085b42eca9da164a
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
+  bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
@@ -393,7 +393,7 @@ CHECKSUMS
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
-  json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
+  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
@@ -403,7 +403,7 @@ CHECKSUMS
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  msgpack (1.8.1) sha256=3fef787cd3965fd119c08a22724a56a93ca25008c3421fc15039f603a8b7c86c
+  msgpack (1.8.3) sha256=8bda4a6428d3244e50d6bd55854d354edbada88a4e1f4f5731a39a0f86bee6a1
   net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
     fileutils (1.8.0)
-    json (2.19.8)
+    json (2.19.9)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.10.0)
@@ -128,7 +128,7 @@ CHECKSUMS
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
-  json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
+  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2


### PR DESCRIPTION
## 1. Overview

This PR (botpress-accuracy-reporters #153) is a routine, dependabot-style bump of four RubyGems dependencies to their latest patch releases.  
Only `Gemfile.lock` files are touched — no `Gemfile`/runtime constraints change — so it is a low-risk maintenance update.

## 2. Key Changes

**Gems updated (with details):**

- **brakeman: 8.0.4 → 8.0.5** — bug-fix release that mostly reduces false positives: SQL-injection FP for `compact_blank`/`compact` on permitted params, inline-render FP for a local named `text`, and fewer FPs when shell escaping is used; also fixes a HAML crash on `.raw` calls, fixes Ruby version parsing (notably for non-CRuby engines), fixes `TemplateAliasProcessor#template_name` arity, and adds `quote_schema_name` to the safe-quote method list.
- **bundler: 4.0.13 → 4.0.14** — two bug fixes to the source "cooldown" mechanism: preserves per-source cooldown when converging sources from the lockfile (#9601), and stops excluding the locked version from cooldown during `bundle update` (#9599).
- **json: 2.19.8 → 2.19.9** — security patch fixing a buffer overflow that could crash the process when generating JSON directly into an IO via `JSON.generate(object, io)` (CVE pending).
- **msgpack: 1.8.1 → 1.8.3** — spans two releases: 1.8.2 resets internal buffer (rmem) pointers when a chunk is fully emptied and drops Ruby 2.5 macOS CI; 1.8.3 is a security fix handling integer overflow when parsing maps.

**Files changed:**

- `ruby-on-rails/Gemfile.lock`
- `ruby/Gemfile.lock`

## 3. Summary

A patch-level dependency refresh across the project's two lockfiles.
All bumps are backward-compatible patch releases; the most security-relevant are the `json` buffer-overflow fix and the `msgpack` integer-overflow fix.
Safe to merge after CI passes.

## 4. References

- brakeman — [CHANGES.md](https://github.com/presidentbeef/brakeman/blob/main/CHANGES.md)
- bundler — [CHANGELOG.md > 4.0.14](https://github.com/ruby/rubygems/blob/master/bundler/CHANGELOG.md#4014--2026-06-10)
- json — [CHANGES.md > 2.19.9](https://github.com/ruby/json/blob/master/CHANGES.md#2026-06-11-2199)
- msgpack — [compare v1.8.1...v1.8.3](https://github.com/msgpack/msgpack-ruby/compare/v1.8.1...v1.8.3)