### PR TITLE
[ruby-on-rails] Bump Docker from 29.5.2 to 29.5.3

### DIFF
--- a/ruby-on-rails/README.md
+++ b/ruby-on-rails/README.md
@@ -4,7 +4,7 @@
 - Ruby 4.0.5
 - Gemfile 4.0.12
 - Bundler 4.0.12
-- Docker 29.5.2
+- Docker 29.5.3
 
 ## 2. Setup Docker
 


### PR DESCRIPTION
## 1. Overview 

The primary differences between Docker 29.5.2 and Docker 29.5.3 are patch-level bug fixes, dependencies updates, and network driver stability patches introduced in the [Docker Engine 29.5.3 release](https://docs.docker.com/engine/release-notes/29/).

## 2. 🐛 Bug Fixes & Enhancements

- **Containerd Storage**: Reduced `docker system df` command errors when pulling or pruning images at the exact same time using the containerd image store
- **Host Networking**: Resolved installation failures for specific plugins that explicitly require host networking

## 3. 🌐 Rootless Mode Improvements

- **AWS Support**: Fixed AWS Instance Metadata Service (IMDS) access issues when using `gvisor-tap-vsock`
- **UDP Forwarding**: Corrected UDP port forwarding behaviors for non-loopback clients

## 4. 📦 Upstream Package & Dependency Updates

- **Go Runtime**: Upgraded the underlying Go engine to version 1.26.4
- **Containerd**: Updated containerd static binaries to version v2.2.4
- **RootlessKit**: Lifted RootlessKit to version v3.0.1

## 5. References

- [Docker Engine version 29 release notes](https://docs.docker.com/engine/release-notes/29/)
- [Docker Engine: Releases, patches & end-of-life - Versio.io](https://www.versio.io/en/product-release-end-of-life-eol-docker-docker-engine.html)