### PR TITLE
[ruby-on-rails] Update RBS Collection

### DIFF
--- a/ruby-on-rails/docker-compose.yml
+++ b/ruby-on-rails/docker-compose.yml
@@ -14,7 +14,12 @@ services:
     volumes:
       - .:/app
       - bundle:/app/vendor/bundle
+      # Back the RBS collection with a named volume so it is not on the
+      # world-writable Windows bind mount, which breaks FileUtils.remove_entry_secure.
+      - gem_rbs_collection:/app/.gem_rbs_collection
 
 volumes:
   bundle:
+    driver: local
+  gem_rbs_collection:
     driver: local

--- a/ruby-on-rails/rbs_collection.lock.yaml
+++ b/ruby-on-rails/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionmailer
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionpack
@@ -22,7 +22,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actiontext
@@ -30,7 +30,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionview
@@ -38,7 +38,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activejob
@@ -46,7 +46,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activemodel
@@ -54,7 +54,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activerecord
@@ -62,7 +62,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activestorage
@@ -70,7 +70,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activesupport
@@ -78,7 +78,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: base64
@@ -94,7 +94,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: concurrent-ruby
@@ -102,7 +102,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: connection_pool
@@ -110,7 +110,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: csv
@@ -118,7 +118,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: date
@@ -134,7 +134,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: digest
@@ -146,7 +146,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: erb
@@ -166,7 +166,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: i18n
@@ -174,7 +174,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: io-console
@@ -190,7 +190,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: mail
@@ -198,7 +198,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: marcel
@@ -206,7 +206,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: mini_mime
@@ -214,7 +214,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: minitest
@@ -222,7 +222,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: monitor
@@ -238,7 +238,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: nokogiri
@@ -246,7 +246,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: openssl
@@ -274,7 +274,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rails-dom-testing
@@ -282,7 +282,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rails-html-sanitizer
@@ -290,7 +290,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: railties
@@ -298,7 +298,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -306,7 +306,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: random-formatter
@@ -342,7 +342,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: time
@@ -362,7 +362,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 3f5e8df1ce89ea06067fa42263012c968b4e583e
+    revision: 3099a933aa5114fb44c04b92c63da49df624123c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: uri


### PR DESCRIPTION
## 1. Mainly For

To fix the following error when running `docker-compose exec app bundle exec rbs collection update`.

<details>
<summary>Error Log</summary>

```
Updating to logger:1.7 (logger@3099a933aa5) from logger:1.7 (logger@3099a933aa5)
bundler: failed to load command: rbs (/app/vendor/bundle/ruby/4.0.0/bin/rbs)
/app/vendor/bundle/ruby/4.0.0/gems/fileutils-1.8.0/lib/fileutils.rb:1366:in 'FileUtils.remove_entry_secure': parent directory is world writable, FileUtils#remove_entry_secure does not work; abort: "/app/.gem_rbs_collection/logger/1.7" (parent directory mode 40777) (ArgumentError)

      raise ArgumentError, "parent directory is world writable, FileUtils#remove_entry_secure does not work; abort: #{path.inspect} (parent directory mode #{'%o' % parent_...
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        from /app/vendor/bundle/ruby/4.0.0/gems/rbs-4.0.2/lib/rbs/collection/sources/git.rb:63:in 'RBS::Collection::Sources::Git#install'
        from /app/vendor/bundle/ruby/4.0.0/gems/rbs-4.0.2/lib/rbs/collection/installer.rb:21:in 'block in RBS::Collection::Installer#install_from_lockfile'
        from /app/vendor/bundle/ruby/4.0.0/gems/rbs-4.0.2/lib/rbs/collection/installer.rb:20:in 'Hash#each_value'
        from /app/vendor/bundle/ruby/4.0.0/gems/rbs-4.0.2/lib/rbs/collection/installer.rb:20:in 'RBS::Collection::Installer#install_from_lockfile'
        from /app/vendor/bundle/ruby/4.0.0/gems/rbs-4.0.2/lib/rbs/cli.rb:1101:in 'RBS::CLI#run_collection'
        from /app/vendor/bundle/ruby/4.0.0/gems/rbs-4.0.2/lib/rbs/cli.rb:141:in 'RBS::CLI#run'
        from /app/vendor/bundle/ruby/4.0.0/gems/rbs-4.0.2/exe/rbs:7:in '<top (required)>'
        from /usr/local/lib/ruby/site_ruby/4.0.0/rubygems.rb:305:in 'Kernel#load'
        from /usr/local/lib/ruby/site_ruby/4.0.0/rubygems.rb:305:in 'Gem.activate_and_load_bin_path'
        from /app/vendor/bundle/ruby/4.0.0/bin/rbs:25:in '<top (required)>'
        from /usr/local/bundle/gems/bundler-4.0.14/lib/bundler/cli/exec.rb:61:in 'Kernel.load'
        from /usr/local/bundle/gems/bundler-4.0.14/lib/bundler/cli/exec.rb:61:in 'Bundler::CLI::Exec#kernel_load'
        from /usr/local/bundle/gems/bundler-4.0.14/lib/bundler/cli/exec.rb:24:in 'Bundler::CLI::Exec#run'
        from /usr/local/bundle/gems/bundler-4.0.14/lib/bundler/cli.rb:508:in 'Bundler::CLI#exec'
        from /usr/local/bundle/gems/bundler-4.0.14/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
        from /usr/local/bundle/gems/bundler-4.0.14/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
        from /usr/local/bundle/gems/bundler-4.0.14/lib/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
        from /usr/local/bundle/gems/bundler-4.0.14/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
        from /usr/local/bundle/gems/bundler-4.0.14/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
        from /usr/local/bundle/gems/bundler-4.0.14/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
        from /usr/local/bundle/gems/bundler-4.0.14/exe/bundle:28:in 'block in <top (required)>'
        from /usr/local/bundle/gems/bundler-4.0.14/lib/bundler/friendly_errors.rb:118:in 'Bundler.with_friendly_errors'
        from /usr/local/bundle/gems/bundler-4.0.14/exe/bundle:20:in '<top (required)>'
        from /usr/local/lib/ruby/site_ruby/4.0.0/rubygems.rb:305:in 'Kernel#load'
        from /usr/local/lib/ruby/site_ruby/4.0.0/rubygems.rb:305:in 'Gem.activate_and_load_bin_path'
        from /usr/local/bundle/bin/bundle:25:in '<main>'
```

</details>


## 2. What was wrong

`.gem_rbs_collection` lived inside the `.:/app` bind mount.  
Docker for Windows exposes bind-mounted directories as mode `0777` (world-writable) inside the Linux container.  
Ruby's `FileUtils.remove_entry_secure` — which `rbs collection update` calls to replace an existing gem's RBS dir — hard-aborts when the target's parent is world-writable (a symlink-attack guard), giving you the parent directory mode `40777` error.

## 3. The fixation

Added a named volume mounted over `/app/.gem_rbs_collection` in each compose file (same pattern as the existing bundle volume).  
A named volume's mount point is created mode `0755`, so the security check passes.  
The path: `.gem_rbs_collection` in each `rbs_collection.yaml` stays unchanged.

## 4. Notes

- The new volume starts empty, so the first `rbs collection update` redownloads everything — expected, and it's what you were running anyway.
- The old host-side `.gem_rbs_collection/` directories are now shadowed by the volume and never touched by the container again. They're harmless but dead; you can delete them on the host if you want a clean tree. (Most of these apps have no `.gitignore`, so if you ever commit them, consider adding `/.gem_rbs_collection/`.)