### PR TITLE
[ruby][ruby-on-rails] Update Gem Dependencies

### DIFF
--- a/ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     fileutils (1.8.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    i18n (1.15.0)
+    i18n (1.15.1)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
     irb (1.18.0)
@@ -390,7 +390,7 @@ CHECKSUMS
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
-  i18n (1.15.0) sha256=ed20037ed7ca75dd36ec486b5fb9696e8e0cfe48f4f80980017932d93e70527f
+  i18n (1.15.1) sha256=505ec5de1f4e6c8a2cb028ef9700ca495f117911643455721dee5abdca797255
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a

--- a/ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
       racc
     builder (3.3.0)
     cgi (0.5.1)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crass (1.0.6)
     csv (3.3.5)
@@ -105,7 +105,7 @@ GEM
     fileutils (1.8.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    i18n (1.14.8)
+    i18n (1.15.0)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
     irb (1.18.0)
@@ -375,7 +375,7 @@ CHECKSUMS
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
-  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
@@ -390,7 +390,7 @@ CHECKSUMS
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
-  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  i18n (1.15.0) sha256=ed20037ed7ca75dd36ec486b5fb9696e8e0cfe48f4f80980017932d93e70527f
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     csv (3.3.5)
     ffi (1.17.4)
     ffi (1.17.4-aarch64-linux-gnu)
@@ -114,7 +114,7 @@ DEPENDENCIES
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
   ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df


### PR DESCRIPTION
## 1. concurrent-ruby: 1.3.6 → 1.3.7

Release date: **16 June 2026** · [Release notes](https://github.com/ruby-concurrency/concurrent-ruby/releases/tag/v1.3.7) · [Compare v1.3.6...v1.3.7](https://github.com/ruby-concurrency/concurrent-ruby/compare/v1.3.6...v1.3.7) (14 commits)

This is primarily a **security / thread-safety bug-fix release** (three Low-severity CVEs).

### 1-1. Security fixes

- **[CVE-2026-54904](https://www.cve.org/CVERecord?id=CVE-2026-54904) — `AtomicReference#update`:** Fixed an infinite retry loop / livelock that occurred when the stored value is `Float::NAN`.
- **[CVE-2026-5490](https://www.cve.org/CVERecord?CVE-2026-5490) — `ReentrantReadWriteLock`:** Fixed a read hold-count overflow that spilled into the write-lock bit after 32,768 reentrant reads.
- **[CVE-2026-54906](https://nvd.nist.gov/vuln/detail/CVE-2026-45490) — `ReadWriteLock`:** Fixed two issues:
  - Any thread could release a write lock held by another thread, breaking write exclusivity.
  - An unconditional decrement on read release dropped the counter to `-1`, blocking all subsequent lock acquisitions.

### 1-2. Infrastructure / other

- Built `concurrent-ruby-ext` correctly on **Darwin 32-bit** systems (#1064).
- Added **SECURITY.md** documentation (#1104).
- Added **Ruby 4.0** to the CI test matrix (#1106).
- Bumped GitHub Actions (`deploy-pages` v4→v5, `upload-pages-artifact` v4→v5).
- Adjusted test timing to reduce transient failures in `ReentrantReadWriteLock` specs.

**Contributors:** @eregon, @joshuay03, @barracuda156 (first contribution).

> Maintainers recommend updating for the security patches, though real-world impact is considered unlikely.

## 2. i18n: 1.14.8 → 1.15.1

[Compare v1.14.8...v1.15.1](https://github.com/ruby-i18n/i18n/compare/v1.14.8...v1.15.1) · [v1.15.1 release notes](https://github.com/ruby-i18n/i18n/releases/tag/v1.15.1) · [v1.15.0 release notes](https://github.com/ruby-i18n/i18n/releases/tag/v1.15.0)

A **minor feature release** focused on concurrency (Fiber/thread safety) and transliteration. The range spans the v1.15.0 release plus the v1.15.1 follow-up fix.

### 2-1. rom v1.15.0 (17 June 2026, by @radar — 18 commits across 13 files, 6 contributors)

#### 2-1-1. Concurrency

- **Fiber-aware config storage (#731):** I18n configuration storage is now compatible with Ruby Fibers.
- **Thread-safe lazy loading, part 2 (#729):** Uses a Mutex to prevent race conditions when two threads lazy-load translations simultaneously; supports immutable/frozen config updates.

#### 2-1-2. Transliteration

- **Preserve unmapped non-ASCII characters (#720):** Non-ASCII characters not present in the transliteration map are now preserved instead of dropped.
- **Polish "O with ogonek" (#733):** Added transliteration support for `Ǫ/ǫ` and `Ǭ/ǭ`.

#### 2-1-3. Tooling / compatibility

- **Dropped Ruby 3.1 support** — now requires **Ruby 3.2+**.
- **CI (#734):** Excluded Ruby 3.2 from the `rails-main` test matrix.

Contributors: @radar, @sobrinho, @chaadow, @lee266.

### 2-2. From v1.15.1 (follow-up release)

- **Fixed fiber storage functionality** — a follow-up correction to the v1.15.0 Fiber work, contributed by first-time contributor @YashaVinter.
- **CI:** Updated the matrix to exclude the Ruby 3.2 + Rails main combination.

## 3. Bottom line

- **concurrent-ruby 1.3.7** is a security patch (three Low-severity CVEs in `AtomicReference` / `ReadWriteLock` / `ReentrantReadWriteLock`) plus CI/platform housekeeping — safe, recommended bump.
- **i18n 1.15.1** adds Fiber-aware storage and thread-safe lazy loading (with a v1.15.1 fix on top), improves transliteration, and **raises the minimum Ruby to 3.2** — verify the project runs on Ruby 3.2+ before merging.