### PR TITLE
[ruby-on-rails] Bump Docker from 29.5.3 to 29.5.4

### DIFF
--- a/ruby-on-rails/README.md
+++ b/ruby-on-rails/README.md
@@ -4,7 +4,7 @@
 - Ruby 4.0.5
 - Gemfile 4.0.12
 - Bundler 4.0.12
-- Docker 29.5.3
+- Docker 29.5.4
 
 ## 2. Setup Docker
 


### PR DESCRIPTION
## 1. Overview

Docker `29.5.4` is a minor point release addressing regressions and packaging bugs in the `29.5.3` line, rather than introducing major features.  
The differences centre on updated runtimes and fixes for container metrics and rootless networking.

## 2. Specific Differences and Adjustments

- **Metrics & Monitoring**: Patched to reduce `docker system df` errors when containers or images are simultaneously pruned by the `containerd` image store
- **Runtimes & Binaries**: The underlying Go runtime has been updated, and static binaries for `containerd` were bumped to v2.2.4
- Rootless & Networking: Resolved issues preventing AWS IMDS access with the `gvisor-tap-vsock` driver and fixed non-loopback UDP port forwarding

## 3. Summary

Are you currently encountering a specific bug or planning a server update?  
If you let me know your underlying environment (e.g., Ubuntu, macOS, Windows) or whether you are using Rootless Docker, I can help you evaluate if this patch is essential for your setup.